### PR TITLE
feat: add ESLint, Prettier, TypeScript strict mode and CI lint gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Install, build, and upload your site
         uses: withastro/action@v6
+        with:
+          node-version: 24
 
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,27 +11,7 @@ permissions:
   id-token: write
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout your repository using git
-        uses: actions/checkout@v6
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - name: Check formatting
-        run: npm run format:check
-      - name: Lint
-        run: npm run lint
-      - name: Type check
-        run: npx astro check
-
   build:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,31 +1,43 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch’s name
   push:
     branches: [main]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
   pages: write
   id-token: write
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Check formatting
+        run: npm run format:check
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npx astro check
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v6
       - name: Install, build, and upload your site
         uses: withastro/action@v6
-        # with:
-        # path: . # The root location of your Astro project inside the repository. (optional)
-        # node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
-        # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
     needs: build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Check formatting
+        run: npm run format:check
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npx astro check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist/
+.astro/
+node_modules/
+package-lock.json

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,0 +1,11 @@
+export default {
+  plugins: ["prettier-plugin-astro"],
+  overrides: [
+    {
+      files: "*.astro",
+      options: {
+        parser: "astro",
+      },
+    },
+  ],
+};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,15 @@ A bilingual (ES/EN) personal portfolio and blog, built with **Astro 6** + **Tail
 
 ## Where to look for what
 
-| If you need to…                                          | Read |
-|----------------------------------------------------------|------|
-| Run / build / deploy the site                            | [README.md → Setup](./README.md#setup) |
-| Understand the directory layout                          | [README.md → Project Structure](./README.md#project-structure) |
-| Get the project's goals and feature list                 | [docs/0-overview.md](./docs/0-overview.md) |
-| Know the dependency versions and why they were picked    | [docs/1-tech-stack.md](./docs/1-tech-stack.md) |
-| Understand routing, content pipeline, i18n, build, deploy| [docs/2-architecture.md](./docs/2-architecture.md) |
-| Check why a non-obvious choice was made                  | [docs/3-design-decisions.md](./docs/3-design-decisions.md) |
-| Add, translate, or schedule a blog post                  | [docs/4-content-authoring.md](./docs/4-content-authoring.md) |
+| If you need to…                                           | Read                                                           |
+| --------------------------------------------------------- | -------------------------------------------------------------- |
+| Run / build / deploy the site                             | [README.md → Setup](./README.md#setup)                         |
+| Understand the directory layout                           | [README.md → Project Structure](./README.md#project-structure) |
+| Get the project's goals and feature list                  | [docs/0-overview.md](./docs/0-overview.md)                     |
+| Know the dependency versions and why they were picked     | [docs/1-tech-stack.md](./docs/1-tech-stack.md)                 |
+| Understand routing, content pipeline, i18n, build, deploy | [docs/2-architecture.md](./docs/2-architecture.md)             |
+| Check why a non-obvious choice was made                   | [docs/3-design-decisions.md](./docs/3-design-decisions.md)     |
+| Add, translate, or schedule a blog post                   | [docs/4-content-authoring.md](./docs/4-content-authoring.md)   |
 
 ## Rules of engagement for agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,22 +26,30 @@ A bilingual (ES/EN) personal portfolio and blog, built with **Astro 6** + **Tail
 2. **Do not invent CMS-like abstractions.** Posts are Markdown files validated by a Zod schema in `src/content.config.ts`. If you need a new field, add it there.
 3. **Slug is the identifier; `idx` is only a sort/translation-link key.** The filename becomes the URL (`/<lang>/blog/<slug>`). `idx` is a frontmatter number used to order listings and to pair translations across languages — it never appears in URLs. See [3-design-decisions.md](./docs/3-design-decisions.md).
 4. **Don't fight Astro's i18n.** `/` is an auto-generated redirect to `/es/`. The empty `src/pages/index.astro` only exists to satisfy Astro's requirement that a file sit at `/` — don't add content to it.
-5. **Verify before claiming done.** Run `npm run build` after any change. Schema violations and broken references fail the build.
-6. **No tracking, no analytics, no comments.** Keep the site lean and static.
+5. **Verify before claiming done.** Run `npm run lint`, `npm run format:check`, `npx astro check`, and `npm run build` after any change. The CI gate enforces all four.
+6. **Keep code formatted.** Run `npm run format` before committing. Prettier with `prettier-plugin-astro` handles all file types.
+7. **No tracking, no analytics, no comments.** Keep the site lean and static.
 
 ## Quick commands
 
 ```bash
-npm install      # prerequisites
-npm run dev      # local dev server on http://localhost:4321
-npm run build    # produces ./dist (what gets deployed)
-npm run preview  # serve ./dist locally
+npm install         # prerequisites
+npm run dev         # local dev server on http://localhost:4321
+npm run build       # produces ./dist (what gets deployed)
+npm run preview     # serve ./dist locally
+npm run lint        # ESLint (.ts, .js, .astro)
+npm run format      # auto-format all files with Prettier
+npm run format:check # check formatting without modifying (CI uses this)
+npx astro check     # TypeScript type checking for .astro and .ts files
 ```
 
 ## Quick map
 
 ```
 astro.config.mjs           # i18n + Tailwind plugin
+eslint.config.mjs          # ESLint flat config (Astro + TypeScript)
+.prettierrc.mjs            # Prettier config (Astro plugin)
+tsconfig.json              # TypeScript strict mode (extends astro/tsconfigs/strict)
 src/content.config.ts      # Blog schema + glob loader
 src/content/blog/{es,en}/  # Markdown posts (one folder per language)
 src/pages/{es,en}/         # Per-language routes
@@ -50,6 +58,6 @@ src/components/            # Layout pieces (Header, Footer, NavBar, …)
 src/layouts/               # Page and Post layouts
 src/styles/global.css      # Tailwind entry + @font-face
 public/                    # Static assets (fonts, icons, images)
-.github/workflows/         # Pages deploy
+.github/workflows/         # CI lint gate + Pages deploy
 docs/                      # In-depth documentation (start at docs/README.md)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ A bilingual (ES/EN) personal portfolio and blog, built with **Astro 6** + **Tail
 1. **English in code and docs, Spanish in conversation.** User preference (see global `CLAUDE.md`).
 2. **Do not invent CMS-like abstractions.** Posts are Markdown files validated by a Zod schema in `src/content.config.ts`. If you need a new field, add it there.
 3. **Slug is the identifier; `idx` is only a sort/translation-link key.** The filename becomes the URL (`/<lang>/blog/<slug>`). `idx` is a frontmatter number used to order listings and to pair translations across languages — it never appears in URLs. See [3-design-decisions.md](./docs/3-design-decisions.md).
-4. **Don't fight Astro's i18n.** `/` is an auto-generated redirect to `/es/`. The empty `src/pages/index.astro` only exists to satisfy Astro's requirement that a file sit at `/` — don't add content to it.
+4. **Don't fight Astro's i18n.** English is the default locale served at `/` (no prefix); Spanish lives under `/es/`. A client-side script in `Layout.astro` auto-detects Spanish browsers and redirects from `/` to `/es/` on first visit.
 5. **Verify before claiming done.** Run `npm run lint`, `npm run format:check`, `npx astro check`, and `npm run build` after any change. The CI gate enforces all four.
 6. **Keep code formatted.** Run `npm run format` before committing. Prettier with `prettier-plugin-astro` handles all file types.
 7. **No tracking, no analytics, no comments.** Keep the site lean and static.

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Deployment is fully automated. On every push to `main`, the workflow at `.github
 Posts live under `src/content/blog/<lang>/<slug>.md`. The filename slug is the identifier: it becomes the URL (`/<lang>/blog/<slug>`). Each post declares the following frontmatter (validated by `src/content.config.ts`):
 
 ```yaml
-idx: 1                        # Sort key (higher = shown first) and translation-link key
+idx: 1 # Sort key (higher = shown first) and translation-link key
 title: "..."
 author: "..."
-pubDate: "..."                # Display date
-pubDateLogical: "YYYY-MM-DD"  # Used to hide future-dated posts
+pubDate: "..." # Display date
+pubDateLogical: "YYYY-MM-DD" # Used to hide future-dated posts
 tags: ["tag1", "tag2"]
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The site is a static, content-driven blog with a landing page, bilingual content
 
 ### Prerequisites
 
-- Node.js `>= 22` (Astro 6 requirement).
+- Node.js `>= 24` (CI pins Node 24).
 - npm (ships with Node).
 
 ### Install and run locally
@@ -34,7 +34,7 @@ npm run format:check # check formatting (used in CI)
 
 ### Deploy
 
-Deployment is fully automated. On every push to `main`, the workflow at `.github/workflows/deploy.yml` runs a lint gate (format check, ESLint, type check via `astro check`), then builds the site with `withastro/action@v6` and publishes the `dist/` output to GitHub Pages.
+Deployment is fully automated. On every push to `main`, two workflows run: `lint.yml` checks formatting, linting, and types; `deploy.yml` builds the site with `withastro/action@v6` and publishes the `dist/` output to GitHub Pages. The lint workflow also runs on every pull request.
 
 ## Project Structure
 
@@ -72,12 +72,10 @@ Deployment is fully automated. On every push to `main`, the workflow at `.github
 │   │   └── PostLayout.astro  # Post-specific layout
 │   ├── pages/
 │   │   ├── 404.astro
-│   │   ├── index.astro       # Placeholder; Astro redirects / → /es/
-│   │   ├── en/               # English routes
-│   │   │   ├── index.astro
-│   │   │   ├── blog.astro
-│   │   │   └── blog/[slug].astro
-│   │   └── es/               # Spanish routes (default locale)
+│   │   ├── index.astro       # English home (default locale, no prefix)
+│   │   ├── blog.astro        # English blog index
+│   │   ├── blog/[slug].astro # English blog post
+│   │   └── es/               # Spanish routes (/es/ prefix)
 │   │       ├── index.astro
 │   │       ├── blog.astro
 │   │       └── blog/[slug].astro
@@ -89,7 +87,7 @@ Deployment is fully automated. On every push to `main`, the workflow at `.github
 
 ### How blog posts work
 
-Posts live under `src/content/blog/<lang>/<slug>.md`. The filename slug is the identifier: it becomes the URL (`/<lang>/blog/<slug>`). Each post declares the following frontmatter (validated by `src/content.config.ts`):
+Posts live under `src/content/blog/<lang>/<slug>.md`. The filename slug is the identifier: it becomes the URL (`/blog/<slug>` for EN, `/es/blog/<slug>` for ES). Each post declares the following frontmatter (validated by `src/content.config.ts`):
 
 ```yaml
 idx: 1 # Sort key (higher = shown first) and translation-link key
@@ -100,7 +98,7 @@ pubDateLogical: "YYYY-MM-DD" # Used to hide future-dated posts
 tags: ["tag1", "tag2"]
 ```
 
-Two posts in different languages with the same `idx` are treated as translations of each other; see `src/i18n/utils.js` (`getPostTranslations`). The slugs themselves are independent per language.
+Two posts in different languages with the same `idx` are treated as translations of each other; see `src/i18n/utils.ts` (`getPostTranslations`). The slugs themselves are independent per language.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ The site is a static, content-driven blog with a landing page, bilingual content
 
 - **Astro 6** — static site generator, content collections, built-in i18n routing.
 - **Tailwind CSS 4** — utility-first styling via the Vite plugin (`@tailwindcss/vite`).
-- **TypeScript** — used in content schema and component props.
-- **GitHub Actions + GitHub Pages** — automated build and deploy on push to `main`.
+- **TypeScript (strict mode)** — used in content schema, component props, and i18n utilities.
+- **ESLint** — linting for `.ts`, `.js`, and `.astro` files via `eslint-plugin-astro` and `typescript-eslint`.
+- **Prettier** — code formatting with `prettier-plugin-astro`.
+- **GitHub Actions + GitHub Pages** — automated lint gate + build + deploy on push to `main`.
 
 ## Setup
 
@@ -25,18 +27,24 @@ npm install          # install dependencies
 npm run dev          # start the dev server at http://localhost:4321
 npm run build        # produce a production build in ./dist
 npm run preview      # serve the production build locally
+npm run lint         # run ESLint
+npm run format       # format all files with Prettier
+npm run format:check # check formatting (used in CI)
 ```
 
 ### Deploy
 
-Deployment is fully automated. On every push to `main`, the workflow at `.github/workflows/deploy.yml` builds the site with `withastro/action@v2` and publishes the `dist/` output to GitHub Pages.
+Deployment is fully automated. On every push to `main`, the workflow at `.github/workflows/deploy.yml` runs a lint gate (format check, ESLint, type check via `astro check`), then builds the site with `withastro/action@v6` and publishes the `dist/` output to GitHub Pages.
 
 ## Project Structure
 
 ```
 .
-├── .github/workflows/        # GitHub Actions (Pages deploy)
+├── .github/workflows/        # GitHub Actions (lint gate + Pages deploy)
 ├── astro.config.mjs          # Astro config (i18n, Tailwind plugin)
+├── eslint.config.mjs         # ESLint flat config (Astro + TypeScript)
+├── .prettierrc.mjs           # Prettier config (Astro plugin)
+├── .prettierignore            # Files excluded from formatting
 ├── docs/                     # Project documentation (see docs/README.md)
 ├── public/                   # Static assets served as-is
 │   ├── favicon.svg
@@ -57,8 +65,8 @@ Deployment is fully automated. On every push to `main`, the workflow at `.github
 │   │       └── es/           # Spanish posts (Markdown)
 │   ├── content.config.ts     # Content collection schema (glob loader)
 │   ├── i18n/
-│   │   ├── ui.js             # Translation strings
-│   │   └── utils.js          # lang helpers + post translation lookup
+│   │   ├── ui.ts             # Translation strings
+│   │   └── utils.ts          # lang helpers + post translation lookup
 │   ├── layouts/
 │   │   ├── Layout.astro      # Base layout (head + Header + Footer)
 │   │   └── PostLayout.astro  # Post-specific layout

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,10 @@ import sitemap from "@astrojs/sitemap";
 // https://astro.build/config
 export default defineConfig({
   site: "https://t1b4lt.github.io",
-  integrations: [icon(), sitemap({ i18n: { defaultLocale: "en", locales: { en: "en", es: "es" } } })],
+  integrations: [
+    icon(),
+    sitemap({ i18n: { defaultLocale: "en", locales: { en: "en", es: "es" } } }),
+  ],
   i18n: {
     defaultLocale: "en",
     locales: ["en", "es"],

--- a/docs/0-overview.md
+++ b/docs/0-overview.md
@@ -16,9 +16,9 @@
 
 | Feature           | Where it lives                                                                                                   |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Landing page      | `src/pages/{es,en}/index.astro`                                                                                  |
-| Blog index        | `src/pages/{es,en}/blog.astro`                                                                                   |
-| Blog post routes  | `src/pages/{es,en}/blog/[slug].astro`                                                                            |
+| Landing page      | `src/pages/index.astro` (EN), `src/pages/es/index.astro` (ES)                                                    |
+| Blog index        | `src/pages/blog.astro` (EN), `src/pages/es/blog.astro` (ES)                                                      |
+| Blog post routes  | `src/pages/blog/[slug].astro` (EN), `src/pages/es/blog/[slug].astro` (ES)                                        |
 | Post content      | `src/content/blog/{es,en}/*.md`                                                                                  |
 | i18n routing      | `astro.config.mjs` (`i18n`) + `src/i18n/`                                                                        |
 | Translation links | `getPostTranslations()` in `src/i18n/utils.ts`                                                                   |

--- a/docs/0-overview.md
+++ b/docs/0-overview.md
@@ -14,19 +14,19 @@
 
 ## Primary features
 
-| Feature            | Where it lives |
-|--------------------|----------------|
-| Landing page       | `src/pages/{es,en}/index.astro` |
-| Blog index         | `src/pages/{es,en}/blog.astro` |
-| Blog post routes   | `src/pages/{es,en}/blog/[slug].astro` |
-| Post content       | `src/content/blog/{es,en}/*.md` |
-| i18n routing       | `astro.config.mjs` (`i18n`) + `src/i18n/` |
-| Translation links  | `getPostTranslations()` in `src/i18n/utils.ts` |
-| Dark mode          | `src/components/DarkModeToggle.astro` + `@variant dark (.dark &)` in `src/styles/global.css` |
-| SEO metadata       | `canonical`, `hreflang`, Open Graph, Twitter Card in `Layout.astro`; `BlogPosting` JSON-LD in `PostLayout.astro` |
-| Sitemap / robots   | `@astrojs/sitemap` + `public/robots.txt` |
-| 404 page           | `src/pages/404.astro` |
-| Scheduled posts    | `pubDateLogical` field, filtered via `filterFuturePosts()` in `src/i18n/utils.ts` |
+| Feature           | Where it lives                                                                                                   |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Landing page      | `src/pages/{es,en}/index.astro`                                                                                  |
+| Blog index        | `src/pages/{es,en}/blog.astro`                                                                                   |
+| Blog post routes  | `src/pages/{es,en}/blog/[slug].astro`                                                                            |
+| Post content      | `src/content/blog/{es,en}/*.md`                                                                                  |
+| i18n routing      | `astro.config.mjs` (`i18n`) + `src/i18n/`                                                                        |
+| Translation links | `getPostTranslations()` in `src/i18n/utils.ts`                                                                   |
+| Dark mode         | `src/components/DarkModeToggle.astro` + `@variant dark (.dark &)` in `src/styles/global.css`                     |
+| SEO metadata      | `canonical`, `hreflang`, Open Graph, Twitter Card in `Layout.astro`; `BlogPosting` JSON-LD in `PostLayout.astro` |
+| Sitemap / robots  | `@astrojs/sitemap` + `public/robots.txt`                                                                         |
+| 404 page          | `src/pages/404.astro`                                                                                            |
+| Scheduled posts   | `pubDateLogical` field, filtered via `filterFuturePosts()` in `src/i18n/utils.ts`                                |
 
 ## Non-goals
 

--- a/docs/1-tech-stack.md
+++ b/docs/1-tech-stack.md
@@ -15,7 +15,7 @@
 
 ## Tooling
 
-- **Node.js ≥ 22** — required by Astro 6.
+- **Node.js ≥ 24** — CI pins Node 24; Astro 6 requires ≥ 22.
 - **TypeScript (strict mode)** — `tsconfig.json` extends `astro/tsconfigs/strict`. Used for the content schema (`src/content.config.ts`), typed component props, and i18n utilities.
 - **ESLint** — flat config in `eslint.config.mjs`. Uses `@eslint/js` (recommended rules), `typescript-eslint` (TS-aware rules), `eslint-plugin-astro` (`.astro` file support), and `eslint-config-prettier` (disables formatting rules that conflict with Prettier).
 - **Prettier** — config in `.prettierrc.mjs`. Uses `prettier-plugin-astro` to format `.astro` files. Ignored paths in `.prettierignore`.
@@ -32,7 +32,7 @@
 ## CI / CD
 
 - **GitHub Actions** — two workflows in `.github/workflows/`.
-- **Lint workflow** (`lint.yml`) — runs on push to `main` and on every pull request. Checks formatting (`prettier --check`), runs ESLint, and runs `astro check` for TypeScript diagnostics. Uses `actions/setup-node@v4` with Node 22 and npm cache.
+- **Lint workflow** (`lint.yml`) — runs on push to `main` and on every pull request. Checks formatting (`prettier --check`), runs ESLint, and runs `astro check` for TypeScript diagnostics. Uses `actions/setup-node@v4` with Node 24 and npm cache.
 - **Deploy workflow** (`deploy.yml`) — runs on push to `main` only. Uses `withastro/action@v6` to build and `actions/deploy-pages@v5` to publish to GitHub Pages.
 
 ## Why these choices

--- a/docs/1-tech-stack.md
+++ b/docs/1-tech-stack.md
@@ -2,16 +2,16 @@
 
 ## Runtime
 
-| Dependency          | Version   | Role |
-|---------------------|-----------|------|
-| `astro`             | `^6.1.7`  | Static site generator, content collections, i18n routing, image pipeline. |
-| `astro-icon`        | `^1.1.5`  | Inline SVG icon component powered by Iconify. |
-| `@fontsource/roboto`| `^5.2.10` | Self-hosted Roboto font files (`.woff2`) managed via npm. |
-| `tailwindcss`       | `^4.2.2`  | Utility-first CSS framework. |
-| `@tailwindcss/vite` | `^4.2.2`  | Official Vite plugin that wires Tailwind 4 into Astro's Vite build. |
-| `@iconify-json/fa6-brands` | `^1.2.6` | FontAwesome 6 brand icons (GitHub, LinkedIn) for astro-icon. |
-| `@iconify-json/fa6-solid`  | `^1.2.4` | FontAwesome 6 solid icons (angles-right) for astro-icon. |
-| `@astrojs/sitemap`         | `^3.7.2` | Generates `sitemap-index.xml` at build time with i18n hreflang support. |
+| Dependency                 | Version   | Role                                                                      |
+| -------------------------- | --------- | ------------------------------------------------------------------------- |
+| `astro`                    | `^6.1.7`  | Static site generator, content collections, i18n routing, image pipeline. |
+| `astro-icon`               | `^1.1.5`  | Inline SVG icon component powered by Iconify.                             |
+| `@fontsource/roboto`       | `^5.2.10` | Self-hosted Roboto font files (`.woff2`) managed via npm.                 |
+| `tailwindcss`              | `^4.2.2`  | Utility-first CSS framework.                                              |
+| `@tailwindcss/vite`        | `^4.2.2`  | Official Vite plugin that wires Tailwind 4 into Astro's Vite build.       |
+| `@iconify-json/fa6-brands` | `^1.2.6`  | FontAwesome 6 brand icons (GitHub, LinkedIn) for astro-icon.              |
+| `@iconify-json/fa6-solid`  | `^1.2.4`  | FontAwesome 6 solid icons (angles-right) for astro-icon.                  |
+| `@astrojs/sitemap`         | `^3.7.2`  | Generates `sitemap-index.xml` at build time with i18n hreflang support.   |
 
 ## Tooling
 

--- a/docs/1-tech-stack.md
+++ b/docs/1-tech-stack.md
@@ -31,10 +31,9 @@
 
 ## CI / CD
 
-- **GitHub Actions** — `.github/workflows/deploy.yml` runs on push to `main`.
-- **Lint job** — runs before the build: `npm run format:check`, `npm run lint`, and `npx astro check`. Uses `actions/setup-node@v4` with Node 22 and npm cache.
-- **Build job** — depends on the lint job passing. Uses `withastro/action@v6` (installs deps, builds, uploads artifact).
-- **Deploy job** — `actions/deploy-pages@v5` publishes the artifact to GitHub Pages.
+- **GitHub Actions** — two workflows in `.github/workflows/`.
+- **Lint workflow** (`lint.yml`) — runs on push to `main` and on every pull request. Checks formatting (`prettier --check`), runs ESLint, and runs `astro check` for TypeScript diagnostics. Uses `actions/setup-node@v4` with Node 22 and npm cache.
+- **Deploy workflow** (`deploy.yml`) — runs on push to `main` only. Uses `withastro/action@v6` to build and `actions/deploy-pages@v5` to publish to GitHub Pages.
 
 ## Why these choices
 

--- a/docs/1-tech-stack.md
+++ b/docs/1-tech-stack.md
@@ -16,7 +16,10 @@
 ## Tooling
 
 - **Node.js ≥ 22** — required by Astro 6.
-- **TypeScript** — `tsconfig.json` extends `astro/tsconfigs/base`. Used for the content schema (`src/content.config.ts`) and typed component props.
+- **TypeScript (strict mode)** — `tsconfig.json` extends `astro/tsconfigs/strict`. Used for the content schema (`src/content.config.ts`), typed component props, and i18n utilities.
+- **ESLint** — flat config in `eslint.config.mjs`. Uses `@eslint/js` (recommended rules), `typescript-eslint` (TS-aware rules), `eslint-plugin-astro` (`.astro` file support), and `eslint-config-prettier` (disables formatting rules that conflict with Prettier).
+- **Prettier** — config in `.prettierrc.mjs`. Uses `prettier-plugin-astro` to format `.astro` files. Ignored paths in `.prettierignore`.
+- **`@astrojs/check`** — runs TypeScript diagnostics across `.astro` and `.ts` files via `npx astro check`.
 - **Vite 7** — bundled by Astro 6; no direct configuration needed beyond the Tailwind plugin.
 - **Zod 4** — ships with Astro; used for content collection schema validation via `astro/zod`.
 
@@ -29,9 +32,9 @@
 ## CI / CD
 
 - **GitHub Actions** — `.github/workflows/deploy.yml` runs on push to `main`.
-- **`actions/checkout@v6`** — checks out the repo.
-- **`withastro/action@v6`** — official Astro action that installs deps, builds, and uploads the artifact.
-- **`actions/deploy-pages@v5`** — publishes the artifact to GitHub Pages.
+- **Lint job** — runs before the build: `npm run format:check`, `npm run lint`, and `npx astro check`. Uses `actions/setup-node@v4` with Node 22 and npm cache.
+- **Build job** — depends on the lint job passing. Uses `withastro/action@v6` (installs deps, builds, uploads artifact).
+- **Deploy job** — `actions/deploy-pages@v5` publishes the artifact to GitHub Pages.
 
 ## Why these choices
 

--- a/docs/2-architecture.md
+++ b/docs/2-architecture.md
@@ -24,15 +24,15 @@ The entire site is prerendered at build time (`output: "static"`, which is Astro
 
 Routing is filesystem-based under `src/pages/`. English is the default locale with no URL prefix; Spanish lives under `/es/`:
 
-| URL                  | File |
-|----------------------|------|
-| `/`                  | `src/pages/index.astro` (English home) |
-| `/blog`              | `src/pages/blog.astro` |
-| `/blog/<slug>`       | `src/pages/blog/[slug].astro` |
-| `/es/`               | `src/pages/es/index.astro` |
-| `/es/blog`           | `src/pages/es/blog.astro` |
-| `/es/blog/<slug>`    | `src/pages/es/blog/[slug].astro` |
-| `/404`               | `src/pages/404.astro` |
+| URL               | File                                   |
+| ----------------- | -------------------------------------- |
+| `/`               | `src/pages/index.astro` (English home) |
+| `/blog`           | `src/pages/blog.astro`                 |
+| `/blog/<slug>`    | `src/pages/blog/[slug].astro`          |
+| `/es/`            | `src/pages/es/index.astro`             |
+| `/es/blog`        | `src/pages/es/blog.astro`              |
+| `/es/blog/<slug>` | `src/pages/es/blog/[slug].astro`       |
+| `/404`            | `src/pages/404.astro`                  |
 
 This is configured in `astro.config.mjs`:
 
@@ -69,7 +69,7 @@ defineCollection({
 
 The **slug** is the identifier of a post. It comes from the filename (`src/content/blog/<lang>/<slug>.md`) and appears verbatim in the URL (`/blog/<slug>` for EN, `/es/blog/<slug>` for ES). Slugs are independent per language (e.g. `modelo-3x-kent-beck` vs `kent-beck-3x-model`) so each language gets a readable URL.
 
-The frontmatter field **`idx`** is *not* an identifier — it is a number used only for:
+The frontmatter field **`idx`** is _not_ an identifier — it is a number used only for:
 
 1. **Sort order** in blog listings. Higher `idx` renders first (`src/pages/<lang>/blog.astro` and `PostList.astro`).
 2. **Translation linking.** Two posts in different languages with the same `idx` are treated as translations of one another.
@@ -90,7 +90,7 @@ The frontmatter field **`idx`** is *not* an identifier — it is a number used o
 
 ### Scheduled publishing
 
-`filterFuturePosts()` in `src/i18n/utils.ts` hides posts whose `pubDateLogical` is in the future. This lets you commit and deploy a post in advance and have it appear automatically on the intended date — no rebuild required *relative to the post itself*, but a build on/after that date will include it.
+`filterFuturePosts()` in `src/i18n/utils.ts` hides posts whose `pubDateLogical` is in the future. This lets you commit and deploy a post in advance and have it appear automatically on the intended date — no rebuild required _relative to the post itself_, but a build on/after that date will include it.
 
 ## Theming / dark mode
 

--- a/docs/2-architecture.md
+++ b/docs/2-architecture.md
@@ -129,7 +129,6 @@ The frontmatter field **`idx`** is _not_ an identifier — it is a number used o
   1. Syncs content and generates types.
   2. Renders all routes to `dist/`.
   3. Optimizes images via `astro:assets` (produces WebP variants).
-- `.github/workflows/deploy.yml` runs on every push to `main`:
-  1. **Lint job:** checks formatting (`prettier --check`), runs ESLint, and runs `astro check` for TypeScript diagnostics. The build is blocked until this passes.
-  2. **Build job:** `withastro/action@v6` installs dependencies and runs the build.
-  3. **Deploy job:** `actions/deploy-pages@v5` publishes `dist/` to GitHub Pages.
+- Two GitHub Actions workflows run on every push to `main`:
+  1. **Lint** (`lint.yml`): checks formatting (`prettier --check`), runs ESLint, and runs `astro check` for TypeScript diagnostics. Also runs on every pull request as a required check.
+  2. **Deploy** (`deploy.yml`): `withastro/action@v6` builds the site, then `actions/deploy-pages@v5` publishes `dist/` to GitHub Pages.

--- a/docs/2-architecture.md
+++ b/docs/2-architecture.md
@@ -130,6 +130,6 @@ The frontmatter field **`idx`** is _not_ an identifier — it is a number used o
   2. Renders all routes to `dist/`.
   3. Optimizes images via `astro:assets` (produces WebP variants).
 - `.github/workflows/deploy.yml` runs on every push to `main`:
-  1. `actions/checkout@v6` checks out the repo.
-  2. `withastro/action@v6` installs dependencies and runs the build.
-  3. `actions/deploy-pages@v5` publishes `dist/` to GitHub Pages.
+  1. **Lint job:** checks formatting (`prettier --check`), runs ESLint, and runs `astro check` for TypeScript diagnostics. The build is blocked until this passes.
+  2. **Build job:** `withastro/action@v6` installs dependencies and runs the build.
+  3. **Deploy job:** `actions/deploy-pages@v5` publishes `dist/` to GitHub Pages.

--- a/docs/3-design-decisions.md
+++ b/docs/3-design-decisions.md
@@ -4,7 +4,7 @@ Non-obvious choices made in this project, and the reasoning behind each.
 
 ## Slug is the identifier; `idx` is a separate link/sort key
 
-**Decision.** The slug (filename) is the identifier of a post — it is what appears in the URL (`/blog/<slug>` for EN, `/es/blog/<slug>` for ES). The frontmatter field `idx` is *not* an identifier; it is a number used only as a sort key in listings and as the key to pair translations across languages.
+**Decision.** The slug (filename) is the identifier of a post — it is what appears in the URL (`/blog/<slug>` for EN, `/es/blog/<slug>` for ES). The frontmatter field `idx` is _not_ an identifier; it is a number used only as a sort key in listings and as the key to pair translations across languages.
 
 **Why.** Slugs are intentionally different across languages (`modelo-3x-kent-beck` vs `kent-beck-3x-model`) because each language wants its own, readable URL — so slug alone cannot link translations. A separate numeric `idx` decouples translation linking from the slug, so renaming a file never breaks the link to its translation. The same number also drives listing order (higher `idx` = shown first).
 

--- a/docs/4-content-authoring.md
+++ b/docs/4-content-authoring.md
@@ -54,8 +54,11 @@ Two implications:
 ## 6. Verify locally
 
 ```bash
-npm run dev     # check both /blog/<slug> (EN) and /es/blog/<slug> (ES)
-npm run build   # catches schema errors and broken references
+npm run dev          # check both /blog/<slug> (EN) and /es/blog/<slug> (ES)
+npm run format       # auto-format any new or changed files
+npm run lint         # catch linting issues
+npx astro check      # TypeScript type checking
+npm run build        # catches schema errors and broken references
 ```
 
-Schema violations (missing or mistyped frontmatter fields) fail the build with a precise error pointing at the offending file.
+Schema violations (missing or mistyped frontmatter fields) fail the build with a precise error pointing at the offending file. The CI lint gate enforces formatting, linting, and type checking before the build runs.

--- a/docs/4-content-authoring.md
+++ b/docs/4-content-authoring.md
@@ -22,13 +22,13 @@ Every post must declare the fields defined in `src/content.config.ts`:
 idx: 3
 title: "Título del post"
 author: "Guillermo Segovia"
-pubDate: "8 de abril de 2026"      # Free-form display string (localized)
-pubDateLogical: "2026-04-08"       # Machine-comparable, used for scheduling
+pubDate: "8 de abril de 2026" # Free-form display string (localized)
+pubDateLogical: "2026-04-08" # Machine-comparable, used for scheduling
 tags: ["astro", "blog"]
 ---
 ```
 
-- `idx` — a number that (a) determines listing order (higher = shown first) and (b) must match across translations so `getPostTranslations` can link them. It does *not* appear in URLs.
+- `idx` — a number that (a) determines listing order (higher = shown first) and (b) must match across translations so `getPostTranslations` can link them. It does _not_ appear in URLs.
 - `pubDate` — shown in the post header; localize it to the target language.
 - `pubDateLogical` — ISO date (`YYYY-MM-DD`), validated at build time with a regex. Posts with a `pubDateLogical` in the future are hidden from listings until that date.
 
@@ -40,7 +40,7 @@ For images, place the file under `public/images/` and reference it with `/images
 
 ## 4. Translations
 
-Each post in `src/content/blog/es/` should have a counterpart in `src/content/blog/en/` with the same `idx`. The `LanguagePicker` in the header uses `getPostTranslations(idx, currentLang)` (in `src/i18n/utils.ts`) to find the counterpart and link to it. The same translations map drives the `hreflang` alternate links in `<head>`. If no translation exists, the picker falls back to a naive path swap — so *always* ship both languages.
+Each post in `src/content/blog/es/` should have a counterpart in `src/content/blog/en/` with the same `idx`. The `LanguagePicker` in the header uses `getPostTranslations(idx, currentLang)` (in `src/i18n/utils.ts`) to find the counterpart and link to it. The same translations map drives the `hreflang` alternate links in `<head>`. If no translation exists, the picker falls back to a naive path swap — so _always_ ship both languages.
 
 ## 5. Scheduling
 

--- a/docs/superpowers/plans/2026-04-18-dependency-hygiene.md
+++ b/docs/superpowers/plans/2026-04-18-dependency-hygiene.md
@@ -12,24 +12,25 @@
 
 ## File Map
 
-| File | Action | Responsibility |
-|------|--------|----------------|
-| `astro.config.mjs` | Modify | Register `icon()` integration |
-| `src/components/Footer.astro` | Modify | Remove Twitter link, replace 2 icon elements with `<Icon>` |
-| `src/components/PostList.astro` | Modify | Replace 1 icon element with `<Icon>` |
-| `src/layouts/Layout.astro` | Modify | Remove 4 FontAwesome `<link>` tags |
-| `src/styles/global.css` | Modify | Replace 4 `@font-face` blocks with 4 `@import` lines |
-| `public/fontawesome/` | Delete | Entire directory |
-| `public/fonts/` | Delete | Entire directory |
-| `docs/3-design-decisions.md` | Modify | Update "Self-hosted fonts and icons" section |
-| `docs/1-tech-stack.md` | Modify | Add new deps, update assets section |
-| `docs/5-improvements.md` | Modify | Remove "Urgent" section (lines 5-144) |
+| File                            | Action | Responsibility                                             |
+| ------------------------------- | ------ | ---------------------------------------------------------- |
+| `astro.config.mjs`              | Modify | Register `icon()` integration                              |
+| `src/components/Footer.astro`   | Modify | Remove Twitter link, replace 2 icon elements with `<Icon>` |
+| `src/components/PostList.astro` | Modify | Replace 1 icon element with `<Icon>`                       |
+| `src/layouts/Layout.astro`      | Modify | Remove 4 FontAwesome `<link>` tags                         |
+| `src/styles/global.css`         | Modify | Replace 4 `@font-face` blocks with 4 `@import` lines       |
+| `public/fontawesome/`           | Delete | Entire directory                                           |
+| `public/fonts/`                 | Delete | Entire directory                                           |
+| `docs/3-design-decisions.md`    | Modify | Update "Self-hosted fonts and icons" section               |
+| `docs/1-tech-stack.md`          | Modify | Add new deps, update assets section                        |
+| `docs/5-improvements.md`        | Modify | Remove "Urgent" section (lines 5-144)                      |
 
 ---
 
 ### Task 1: Create branch and install dependencies
 
 **Files:**
+
 - Modify: `package.json`
 - Modify: `astro.config.mjs`
 
@@ -102,6 +103,7 @@ to replace manually-copied assets in public/."
 ### Task 2: Migrate icons in Footer.astro and remove Twitter link
 
 **Files:**
+
 - Modify: `src/components/Footer.astro`
 
 - [ ] **Step 1: Replace `src/components/Footer.astro` with migrated version**
@@ -154,6 +156,7 @@ const t = useTranslations(lang);
 ```
 
 Changes from original:
+
 - Added `import { Icon } from "astro-icon/components";`
 - Removed the entire Twitter `<a>` block (lines 19-25 of original)
 - Replaced `<i class="fa-brands fa-github">` with `<Icon name="fa6-brands:github" aria-label="GitHub" />`
@@ -174,6 +177,7 @@ Remove the Twitter/X social link, keeping only GitHub and LinkedIn."
 ### Task 3: Migrate icon in PostList.astro
 
 **Files:**
+
 - Modify: `src/components/PostList.astro`
 
 - [ ] **Step 1: Update `src/components/PostList.astro`**
@@ -181,13 +185,13 @@ Remove the Twitter/X social link, keeping only GitHub and LinkedIn."
 Add the Icon import to the frontmatter (after the existing imports, line 2):
 
 ```astro
-import { Icon } from "astro-icon/components";
+import {Icon} from "astro-icon/components";
 ```
 
 Replace line 47:
 
 ```astro
-<span class="fa-solid fa-angles-right mr-2" />
+<span class="fa-solid fa-angles-right mr-2"></span>
 ```
 
 with:
@@ -211,6 +215,7 @@ Mark as aria-hidden since it is purely decorative."
 ### Task 4: Remove FontAwesome from Layout.astro and delete old assets
 
 **Files:**
+
 - Modify: `src/layouts/Layout.astro`
 - Delete: `public/fontawesome/` (entire directory)
 
@@ -219,10 +224,10 @@ Mark as aria-hidden since it is purely decorative."
 Delete lines 57-60:
 
 ```html
-    <link href="/fontawesome/css/fontawesome.min.css" rel="stylesheet" />
-    <link href="/fontawesome/css/brands.min.css" rel="stylesheet" />
-    <link href="/fontawesome/css/regular.min.css" rel="stylesheet" />
-    <link href="/fontawesome/css/solid.min.css" rel="stylesheet" />
+<link href="/fontawesome/css/fontawesome.min.css" rel="stylesheet" />
+<link href="/fontawesome/css/brands.min.css" rel="stylesheet" />
+<link href="/fontawesome/css/regular.min.css" rel="stylesheet" />
+<link href="/fontawesome/css/solid.min.css" rel="stylesheet" />
 ```
 
 - [ ] **Step 2: Delete the `public/fontawesome/` directory**
@@ -255,6 +260,7 @@ Removes ~700 KB of CSS and webfont files."
 ### Task 5: Migrate fonts to @fontsource/roboto and delete old assets
 
 **Files:**
+
 - Modify: `src/styles/global.css`
 - Delete: `public/fonts/` (entire directory)
 
@@ -278,6 +284,7 @@ body {
 ```
 
 Changes from original:
+
 - Removed the 4 `@font-face` blocks (lines 5-32)
 - Added 4 `@import "@fontsource/roboto/*.css"` lines
 - Kept `@variant dark` and `body` rule unchanged
@@ -335,6 +342,7 @@ npm run dev
 ```
 
 Check in browser:
+
 - Home page loads with Roboto font
 - Blog listing shows `angles-right` icon before each post title
 - Footer shows GitHub and LinkedIn icons (no Twitter)
@@ -346,6 +354,7 @@ Check in browser:
 ### Task 7: Update documentation
 
 **Files:**
+
 - Modify: `docs/3-design-decisions.md`
 - Modify: `docs/1-tech-stack.md`
 - Modify: `docs/5-improvements.md`
@@ -383,25 +392,25 @@ with:
 Replace the Runtime table (lines 4-9):
 
 ```markdown
-| Dependency          | Version   | Role |
-|---------------------|-----------|------|
-| `astro`             | `^6.1.7`  | Static site generator, content collections, i18n routing, image pipeline. |
-| `tailwindcss`       | `^4.2.2`  | Utility-first CSS framework. |
-| `@tailwindcss/vite` | `^4.2.2`  | Official Vite plugin that wires Tailwind 4 into Astro's Vite build. |
+| Dependency          | Version  | Role                                                                      |
+| ------------------- | -------- | ------------------------------------------------------------------------- |
+| `astro`             | `^6.1.7` | Static site generator, content collections, i18n routing, image pipeline. |
+| `tailwindcss`       | `^4.2.2` | Utility-first CSS framework.                                              |
+| `@tailwindcss/vite` | `^4.2.2` | Official Vite plugin that wires Tailwind 4 into Astro's Vite build.       |
 ```
 
 with:
 
 ```markdown
-| Dependency          | Version   | Role |
-|---------------------|-----------|------|
-| `astro`             | `^6.1.7`  | Static site generator, content collections, i18n routing, image pipeline. |
-| `astro-icon`        | *         | Inline SVG icon component powered by Iconify. |
-| `@fontsource/roboto`| *         | Self-hosted Roboto font files (`.woff2`) managed via npm. |
-| `tailwindcss`       | `^4.2.2`  | Utility-first CSS framework. |
-| `@tailwindcss/vite` | `^4.2.2`  | Official Vite plugin that wires Tailwind 4 into Astro's Vite build. |
-| `@iconify-json/fa6-brands` | *      | FontAwesome 6 brand icons (GitHub, LinkedIn) for astro-icon. |
-| `@iconify-json/fa6-solid`  | *      | FontAwesome 6 solid icons (angles-right) for astro-icon. |
+| Dependency                 | Version  | Role                                                                      |
+| -------------------------- | -------- | ------------------------------------------------------------------------- |
+| `astro`                    | `^6.1.7` | Static site generator, content collections, i18n routing, image pipeline. |
+| `astro-icon`               | \*       | Inline SVG icon component powered by Iconify.                             |
+| `@fontsource/roboto`       | \*       | Self-hosted Roboto font files (`.woff2`) managed via npm.                 |
+| `tailwindcss`              | `^4.2.2` | Utility-first CSS framework.                                              |
+| `@tailwindcss/vite`        | `^4.2.2` | Official Vite plugin that wires Tailwind 4 into Astro's Vite build.       |
+| `@iconify-json/fa6-brands` | \*       | FontAwesome 6 brand icons (GitHub, LinkedIn) for astro-icon.              |
+| `@iconify-json/fa6-solid`  | \*       | FontAwesome 6 solid icons (angles-right) for astro-icon.                  |
 ```
 
 Replace the "Assets (self-hosted)" section (lines 19-22):
@@ -436,7 +445,9 @@ The file should go from:
 Audit of the current codebase with concrete suggestions. The project is sound and the decisions in [`3-design-decisions.md`](./3-design-decisions.md) are respected in practice — the items below are refinements, not blockers.
 
 ## Urgent (dependency hygiene)
+
 ...
+
 ## Critical (SEO / a11y)
 ```
 
@@ -496,6 +507,7 @@ git log --oneline feat/dependency-hygiene --not main
 ```
 
 Expected: 6 commits in order:
+
 1. `feat: install astro-icon, fontsource, and iconify packages`
 2. `feat(footer): migrate icons to astro-icon and remove Twitter link`
 3. `feat(post-list): migrate angles-right icon to astro-icon`

--- a/docs/superpowers/plans/2026-04-18-en-at-root-routing.md
+++ b/docs/superpowers/plans/2026-04-18-en-at-root-routing.md
@@ -11,6 +11,7 @@
 **Spec:** `docs/5-improvements.md` section "Critical: Eliminate the root redirect flash — EN-at-root with client-side language detection" (lines 7–174). This plan implements that section verbatim.
 
 **Out of scope (do NOT touch):**
+
 - `hreflang` / `canonical` / `x-default` tags in `Layout.astro` (item #2 in improvements doc)
 - `@astrojs/sitemap` and `robots.txt` (item #3)
 - Follow-up documentation updates to `docs/3-design-decisions.md` (spec lines 168–173)
@@ -20,6 +21,7 @@
 ## File Structure
 
 **Modified:**
+
 - `astro.config.mjs` — flip i18n config + add `site`
 - `src/i18n/ui.js` — change `defaultLang` from `"es"` to `"en"`
 - `src/i18n/utils.js` — `getPostTranslations` drops EN prefix
@@ -27,13 +29,16 @@
 - `src/layouts/Layout.astro` — add inline language-detection script in `<head>`
 
 **Created:**
+
 - `src/pages/blog.astro` — EN blog index (was `src/pages/en/blog.astro`)
 - `src/pages/blog/[slug].astro` — EN blog post (was `src/pages/en/blog/[slug].astro`)
 
 **Overwritten:**
+
 - `src/pages/index.astro` — EN home content (was a placeholder comment)
 
 **Deleted:**
+
 - `src/pages/en/index.astro`
 - `src/pages/en/blog.astro`
 - `src/pages/en/blog/[slug].astro`
@@ -47,6 +52,7 @@
 This task is atomic: config, page relocation, helpers and picker all land in a single commit because any intermediate state leaves the site broken (cross-language navigation depends on every piece).
 
 **Files:**
+
 - Modify: `astro.config.mjs`
 - Modify: `src/i18n/ui.js:6`
 - Overwrite: `src/pages/index.astro`
@@ -114,18 +120,23 @@ import Layout from "../layouts/Layout.astro";
   <div class="flex justify-center p-10">
     <div class="w-full lg:w-1/2 space-y-5 text-lg">
       <hr class="border-zinc-900 dark:border-slate-200" />
-      <h1 class="text-3xl font-bold">Guillermo: Innovation, Technology and Constant Growth</h1>
+      <h1 class="text-3xl font-bold">
+        Guillermo: Innovation, Technology and Constant Growth
+      </h1>
       <hr class="my-6 border-zinc-900 dark:border-slate-200" />
       <p>
-        Welcome to my blog, Guillermo's blog!
-        I'm Guillermo, a passionate IT professional with a background in innovation and digital development.
+        Welcome to my blog, Guillermo's blog! I'm Guillermo, a passionate IT
+        professional with a background in innovation and digital development.
         Let me introduce you to my story and interests.
       </p>
       <h2 class="text-3xl font-bold">About me</h2>
       <p>
-        Currently working in the CDO innovation area at Telefónica, in a position that allows me to participate in the rapid prototyping of digital products.
-        My team is specialized in applying emerging technologies to improve existing products and develop new ones.
-        My job is to carry out the rapid prototyping of digital products, applying these emerging technologies to:
+        Currently working in the CDO innovation area at Telefónica, in a
+        position that allows me to participate in the rapid prototyping of
+        digital products. My team is specialized in applying emerging
+        technologies to improve existing products and develop new ones. My job
+        is to carry out the rapid prototyping of digital products, applying
+        these emerging technologies to:
         <ul class="space-y-4 ml-4">
           <li>1. improve existing solutions,</li>
           <li>2. create new experiences for our users and</li>
@@ -134,32 +145,69 @@ import Layout from "../layouts/Layout.astro";
       </p>
       <h2 class="text-3xl font-bold">My areas of interest</h2>
       <p>
-        As a professional, my curiosity and passion lead me to explore diverse areas:
+        As a professional, my curiosity and passion lead me to explore diverse
+        areas:
         <ul class="space-y-4 ml-4">
-          <li><b>• Machine Learning:</b> I am fascinated by the potential of machine learning techniques to transform the way we interact with technology. From traditional classification algorithms and neural networks to new Generative AI trends, which are giving us so many opportunities. I am always looking to learn more and apply this knowledge in innovative projects.</li>
-          <li><b>• Software and Application Development:</b> Programming was my gateway to the world of technology. I love building solutions from scratch, whether it's developing web, mobile, backend systems or all at once for a single solution. Creativity, problem solving and creating tangible solutions are my driving force.</li>
-          <li><b>• Data Analysis:</b> Data is the new oil, and I am a passionate geologist. Exploring data sets, extracting insights and making evidence-based decisions is something I am passionate about. From SQL to visualization tools, I am always honing my analytical skills.</li>
+          <li>
+            <b>• Machine Learning:</b> I am fascinated by the potential of machine
+            learning techniques to transform the way we interact with technology.
+            From traditional classification algorithms and neural networks to new
+            Generative AI trends, which are giving us so many opportunities. I am
+            always looking to learn more and apply this knowledge in innovative projects.
+          </li>
+          <li>
+            <b>• Software and Application Development:</b> Programming was my gateway
+            to the world of technology. I love building solutions from scratch, whether
+            it's developing web, mobile, backend systems or all at once for a single
+            solution. Creativity, problem solving and creating tangible solutions
+            are my driving force.
+          </li>
+          <li>
+            <b>• Data Analysis:</b> Data is the new oil, and I am a passionate geologist.
+            Exploring data sets, extracting insights and making evidence-based decisions
+            is something I am passionate about. From SQL to visualization tools, I
+            am always honing my analytical skills.
+          </li>
         </ul>
       </p>
       <h2 class="text-3xl font-bold">My professional goals</h2>
       <p>
         My professional path is focused on continuous growth. I aspire to:
         <ul class="space-y-4 ml-4">
-          <li><b>• Keep Learning:</b> Never stop learning. I feel, <i>and hope</i>, that this curiosity that technology and innovation arouses in me will not cease. Courses, conferences, books... any source of knowledge is welcome.</li>
-          <li><b>• Contribute to the Community:</b> Share what I know and learn from others. Collaboration in the technological field is key to achieving unimaginable goals. I really believe in the power and philosophy of Open Source</li>
-          <li><b>• Innovate:</b> Always look for new ways to solve problems and create disruptive solutions. Keeping up to date with what is happening in this world and fitting the pieces together in ways that have not been done before.</li>
-          <li><b>• Create:</b> Build tangible solutions that have a positive impact. From mobile applications to artificial intelligence systems, I am always looking to create solutions that reach people.</li>
+          <li>
+            <b>• Keep Learning:</b> Never stop learning. I feel, <i>and hope</i
+            >, that this curiosity that technology and innovation arouses in me
+            will not cease. Courses, conferences, books... any source of
+            knowledge is welcome.
+          </li>
+          <li>
+            <b>• Contribute to the Community:</b> Share what I know and learn from
+            others. Collaboration in the technological field is key to achieving unimaginable
+            goals. I really believe in the power and philosophy of Open Source
+          </li>
+          <li>
+            <b>• Innovate:</b> Always look for new ways to solve problems and create
+            disruptive solutions. Keeping up to date with what is happening in this
+            world and fitting the pieces together in ways that have not been done
+            before.
+          </li>
+          <li>
+            <b>• Create:</b> Build tangible solutions that have a positive impact.
+            From mobile applications to artificial intelligence systems, I am always
+            looking to create solutions that reach people.
+          </li>
         </ul>
       </p>
       <h2 class="text-3xl font-bold">Visit my blog</h2>
       <p>
-        In this blog, I will share my experiences, knowledge and opinions on topics related to technology, innovation and professional growth.
-        I hope you enjoy reading it!
+        In this blog, I will share my experiences, knowledge and opinions on
+        topics related to technology, innovation and professional growth. I hope
+        you enjoy reading it!
       </p>
-      <p>
-        See you soon!
-      </p>
-</Layout>
+      <p>See you soon!</p>
+    </div>
+  </div></Layout
+>
 ```
 
 ### Step 1.4: Create `src/pages/blog.astro`
@@ -170,21 +218,21 @@ import Layout from "../layouts/Layout.astro";
 ---
 import Layout from "../layouts/Layout.astro";
 import PostList from "../components/PostList.astro";
-import { getCollection } from 'astro:content';
+import { getCollection } from "astro:content";
 
-const posts = await getCollection('blog', ({ id }) => {
-  return id.startsWith('en/');
+const posts = await getCollection("blog", ({ id }) => {
+  return id.startsWith("en/");
 });
 
 // Ordenar por idx
 const sortedPosts = posts.sort((a, b) => b.data.idx - a.data.idx);
 
 // Convertir al formato esperado por PostList
-const formattedPosts = sortedPosts.map(entry => {
-  const slug = entry.id.replace('en/', '');
+const formattedPosts = sortedPosts.map((entry) => {
+  const slug = entry.id.replace("en/", "");
   return {
     url: `/blog/${slug}`,
-    frontmatter: entry.data
+    frontmatter: entry.data,
   };
 });
 ---
@@ -200,17 +248,17 @@ const formattedPosts = sortedPosts.map(entry => {
 
 ```astro
 ---
-import { getCollection, render } from 'astro:content';
-import PostLayout from '../../layouts/PostLayout.astro';
-import { getPostTranslations } from '../../i18n/utils';
+import { getCollection, render } from "astro:content";
+import PostLayout from "../../layouts/PostLayout.astro";
+import { getPostTranslations } from "../../i18n/utils";
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection('blog', ({ id }) => {
-    return id.startsWith('en/');
+  const blogEntries = await getCollection("blog", ({ id }) => {
+    return id.startsWith("en/");
   });
 
-  return blogEntries.map(entry => {
-    const slug = entry.id.replace('en/', '');
+  return blogEntries.map((entry) => {
+    const slug = entry.id.replace("en/", "");
     return {
       params: { slug },
       props: { entry },
@@ -221,7 +269,7 @@ export async function getStaticPaths() {
 const { entry } = Astro.props;
 const { Content } = await render(entry);
 
-const translations = await getPostTranslations(entry.data.idx, 'en');
+const translations = await getPostTranslations(entry.data.idx, "en");
 ---
 
 <PostLayout frontmatter={entry.data} translations={translations}>
@@ -315,6 +363,7 @@ function changeLangFromUrl(actualUrl: URL, lang: string) {
 ```
 
 What changed:
+
 - `changeLangFromUrl` no longer assumes every URL starts with `/<lang>/`. It strips the `/es` prefix when present and, when going back to Spanish, prepends `/es`.
 - Anchor now has `data-lang={lang}` and `onclick="localStorage.setItem('lang', this.dataset.lang)"` so clicking the picker persists the user's choice for future visits.
 
@@ -339,7 +388,6 @@ Expected: neither command errors; blog directory listings have the same entries.
 ### Step 1.10: Verify in the dev server
 
 - [ ] Run `npm run dev` and open the site. Confirm manually:
-
   - `/` renders the English home (no redirect, no flash).
   - `/es/` renders the Spanish home.
   - `/blog` renders the English blog index; each link points to `/blog/<slug>` (no `/en/` prefix).
@@ -386,6 +434,7 @@ Expected: commit created.
 Adds a redirect-before-paint for Spanish browsers landing on `/` and for users with an explicit preference stored from a previous visit. Independent of Task 1 — the site works correctly without this script; this only makes the language choice auto-apply.
 
 **Files:**
+
 - Modify: `src/layouts/Layout.astro`
 
 ### Step 2.1: Add the inline script to `Layout.astro`
@@ -394,47 +443,50 @@ Adds a redirect-before-paint for Spanish browsers landing on `/` and for users w
 
 ```astro
 <head>
-    <meta charset="UTF-8" />
-    <script is:inline>
-      (function () {
-        try {
-          const path = location.pathname;
-          const isSpanishPath = path === "/es" || path.startsWith("/es/");
-          const stored = localStorage.getItem("lang");
+  <meta charset="UTF-8" />
+  <script is:inline>
+    (function () {
+      try {
+        const path = location.pathname;
+        const isSpanishPath = path === "/es" || path.startsWith("/es/");
+        const stored = localStorage.getItem("lang");
 
-          // Explicit user preference always wins — it can even undo the auto-detect.
-          if (stored === "es" && !isSpanishPath) {
-            location.replace("/es" + (path === "/" ? "/" : path));
-            return;
-          }
-          if (stored === "en" && isSpanishPath) {
-            location.replace(path.replace(/^\/es/, "") || "/");
-            return;
-          }
+        // Explicit user preference always wins — it can even undo the auto-detect.
+        if (stored === "es" && !isSpanishPath) {
+          location.replace("/es" + (path === "/" ? "/" : path));
+          return;
+        }
+        if (stored === "en" && isSpanishPath) {
+          location.replace(path.replace(/^\/es/, "") || "/");
+          return;
+        }
 
-          // Auto-detection only on the root path. Deep links never bounce.
-          if (stored === null && path === "/") {
-            const langs = navigator.languages && navigator.languages.length
+        // Auto-detection only on the root path. Deep links never bounce.
+        if (stored === null && path === "/") {
+          const langs =
+            navigator.languages && navigator.languages.length
               ? navigator.languages
               : [navigator.language];
-            const prefersSpanish = langs.some((l) => (l || "").toLowerCase().startsWith("es"));
-            if (prefersSpanish) location.replace("/es/");
-          }
-        } catch (_) {
-          // localStorage unavailable (private mode, SSR, etc.) → serve whatever the URL says.
+          const prefersSpanish = langs.some((l) =>
+            (l || "").toLowerCase().startsWith("es"),
+          );
+          if (prefersSpanish) location.replace("/es/");
         }
-      })();
-    </script>
-    <meta name="description" content="T1b4lt's blog" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="generator" content={Astro.generator} />
-    <link href="/fontawesome/css/fontawesome.min.css" rel="stylesheet" />
-    <link href="/fontawesome/css/brands.min.css" rel="stylesheet" />
-    <link href="/fontawesome/css/regular.min.css" rel="stylesheet" />
-    <link href="/fontawesome/css/solid.min.css" rel="stylesheet" />
-    <title>{title}</title>
-  </head>
+      } catch (_) {
+        // localStorage unavailable (private mode, SSR, etc.) → serve whatever the URL says.
+      }
+    })();
+  </script>
+  <meta name="description" content="T1b4lt's blog" />
+  <meta name="viewport" content="width=device-width" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="generator" content={Astro.generator} />
+  <link href="/fontawesome/css/fontawesome.min.css" rel="stylesheet" />
+  <link href="/fontawesome/css/brands.min.css" rel="stylesheet" />
+  <link href="/fontawesome/css/regular.min.css" rel="stylesheet" />
+  <link href="/fontawesome/css/solid.min.css" rel="stylesheet" />
+  <title>{title}</title>
+</head>
 ```
 
 Leave the rest of the file (imports, the outer `<html>` tag, `<body>` contents) exactly as it is.
@@ -460,7 +512,6 @@ Expected: both files print `1`.
 - [ ] Run `npm run dev` and walk through each scenario. Use the browser devtools console to set/clear `localStorage` between runs (`localStorage.clear()` and `localStorage.setItem('lang', 'es')`).
 
   Run every check from the spec's edge-case list:
-
   - [ ] **EN browser, empty localStorage, visit `/`** → renders English home instantly. No redirect.
   - [ ] **ES browser, empty localStorage, visit `/`** → redirects to `/es/` before paint. No visible flash of the English page.
   - [ ] **ES browser, empty localStorage, visit `/blog/<slug>`** → does **not** bounce. English post renders. (Deep links never auto-redirect.)

--- a/docs/superpowers/plans/2026-04-18-linting-formatting-strict-ts.md
+++ b/docs/superpowers/plans/2026-04-18-linting-formatting-strict-ts.md
@@ -1,0 +1,408 @@
+# ESLint + Prettier + TypeScript Strict Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add automated code quality tooling (ESLint, Prettier, TypeScript strict mode) and a CI lint gate to the Astro blog.
+
+**Architecture:** Install ESLint with the Astro plugin and TypeScript support via `typescript-eslint`. Install Prettier with the Astro plugin. Enable TypeScript strict mode and fix any resulting errors. Add a lint job to the GitHub Actions workflow that runs before the existing build+deploy jobs. All config uses flat config format (ESLint v9+).
+
+**Tech Stack:** ESLint v9+ (flat config), eslint-plugin-astro, typescript-eslint, Prettier, prettier-plugin-astro, TypeScript strict mode.
+
+---
+
+### Task 1: Install ESLint with Astro and TypeScript support
+
+**Files:**
+
+- Modify: `package.json`
+- Create: `eslint.config.mjs`
+
+- [ ] **Step 1: Install ESLint dependencies**
+
+Run:
+
+```bash
+npm install -D eslint @eslint/js eslint-plugin-astro typescript-eslint
+```
+
+Expected: packages added to `devDependencies` in `package.json`.
+
+- [ ] **Step 2: Create ESLint flat config**
+
+Create `eslint.config.mjs`:
+
+```javascript
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+  {
+    ignores: ["dist/", ".astro/", "node_modules/"],
+  },
+];
+```
+
+- [ ] **Step 3: Add lint script to package.json**
+
+Add to `"scripts"`:
+
+```json
+"lint": "eslint ."
+```
+
+- [ ] **Step 4: Run ESLint and fix any errors**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: either clean output or a list of warnings/errors. Fix any real errors. Common expected issues:
+
+- `no-unused-vars` on underscore-prefixed params (e.g., `_currentLang` in `src/i18n/utils.ts:46`) — these are already handled by `typescript-eslint` which ignores `_`-prefixed vars by default.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json eslint.config.mjs
+git commit -m "feat: add ESLint with Astro and TypeScript support"
+```
+
+---
+
+### Task 2: Install Prettier with Astro support
+
+**Files:**
+
+- Modify: `package.json`
+- Create: `.prettierrc.mjs`
+- Create: `.prettierignore`
+
+- [ ] **Step 1: Install Prettier dependencies**
+
+Run:
+
+```bash
+npm install -D prettier prettier-plugin-astro
+```
+
+- [ ] **Step 2: Create Prettier config**
+
+Create `.prettierrc.mjs`:
+
+```javascript
+export default {
+  plugins: ["prettier-plugin-astro"],
+  overrides: [
+    {
+      files: "*.astro",
+      options: {
+        parser: "astro",
+      },
+    },
+  ],
+};
+```
+
+- [ ] **Step 3: Create .prettierignore**
+
+Create `.prettierignore`:
+
+```
+dist/
+.astro/
+node_modules/
+package-lock.json
+```
+
+- [ ] **Step 4: Add format scripts to package.json**
+
+Add to `"scripts"`:
+
+```json
+"format": "prettier --write .",
+"format:check": "prettier --check ."
+```
+
+- [ ] **Step 5: Run format check to see current state**
+
+Run:
+
+```bash
+npm run format:check
+```
+
+Expected: some files will likely not match Prettier's formatting. This is expected — we will format them in the next step.
+
+- [ ] **Step 6: Run formatter on entire codebase**
+
+Run:
+
+```bash
+npm run format
+```
+
+Expected: files reformatted. Review the diff with `git diff` to ensure no unintended changes.
+
+- [ ] **Step 7: Install eslint-config-prettier to avoid ESLint/Prettier conflicts**
+
+Run:
+
+```bash
+npm install -D eslint-config-prettier
+```
+
+Then update `eslint.config.mjs` to add it as the last config entry:
+
+```javascript
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+import prettier from "eslint-config-prettier";
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+  prettier,
+  {
+    ignores: ["dist/", ".astro/", "node_modules/"],
+  },
+];
+```
+
+- [ ] **Step 8: Verify lint still passes after Prettier integration**
+
+Run:
+
+```bash
+npm run lint
+```
+
+Expected: clean output (no ESLint rules conflicting with Prettier formatting).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add package.json package-lock.json .prettierrc.mjs .prettierignore eslint.config.mjs src/ astro.config.mjs
+git commit -m "feat: add Prettier with Astro plugin and format codebase"
+```
+
+---
+
+### Task 3: Enable TypeScript strict mode and fix errors
+
+**Files:**
+
+- Modify: `tsconfig.json`
+- Possibly modify: `src/i18n/utils.ts`, `src/pages/404.astro`, `src/layouts/PostLayout.astro`, other `.astro` files
+
+- [ ] **Step 1: Enable strict mode in tsconfig.json**
+
+Change `tsconfig.json` to:
+
+```json
+{
+  "extends": "astro/tsconfigs/strict"
+}
+```
+
+This switches from `astro/tsconfigs/base` to `astro/tsconfigs/strict`, which enables `strict: true` and related TypeScript options. This is the Astro-recommended way to enable strict mode.
+
+- [ ] **Step 2: Run type checking to find errors**
+
+Run:
+
+```bash
+npx astro check
+```
+
+Expected: this will report TypeScript errors across `.astro` and `.ts` files. Common expected issues:
+
+1. **`src/layouts/PostLayout.astro`** — `Astro.props` is untyped (no `Props` interface). `frontmatter` and `translations` will be `any`. Fix by adding a `Props` interface.
+2. **`src/pages/404.astro`** — importing from `../../public/images/lost.gif` may need type attention.
+3. **Possible `string | undefined` issues** in various places where strict null checks are now enforced.
+
+- [ ] **Step 3: Fix PostLayout.astro — add Props interface**
+
+In `src/layouts/PostLayout.astro`, the frontmatter section currently has:
+
+```typescript
+const { frontmatter, translations } = Astro.props;
+```
+
+Add a `Props` interface before this line:
+
+```typescript
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  frontmatter: CollectionEntry<"blog">["data"];
+  translations?: Record<string, string>;
+}
+```
+
+- [ ] **Step 4: Fix any remaining type errors found by astro check**
+
+Run `npx astro check` again and fix each error. For each fix:
+
+- Prefer adding type annotations over using `as` casts.
+- Prefer narrowing (null checks, type guards) over `!` assertions.
+
+- [ ] **Step 5: Run full verification**
+
+Run:
+
+```bash
+npx astro check && npm run lint && npm run build
+```
+
+Expected: all three commands pass cleanly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tsconfig.json src/
+git commit -m "feat: enable TypeScript strict mode and fix type errors"
+```
+
+---
+
+### Task 4: Add CI lint gate to GitHub Actions
+
+**Files:**
+
+- Modify: `.github/workflows/deploy.yml`
+
+- [ ] **Step 1: Add a lint job that runs before build**
+
+Modify `.github/workflows/deploy.yml` to add a `lint` job before the `build` job. The `build` job should depend on `lint` passing.
+
+Replace the full file content with:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Check formatting
+        run: npm run format:check
+      - name: Lint
+        run: npm run lint
+      - name: Type check
+        run: npx astro check
+
+  build:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v6
+      - name: Install, build, and upload your site
+        uses: withastro/action@v6
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+```
+
+- [ ] **Step 2: Install @astrojs/check for CI type checking**
+
+The `astro check` command requires `@astrojs/check`:
+
+Run:
+
+```bash
+npm install -D @astrojs/check
+```
+
+- [ ] **Step 3: Verify all scripts work locally**
+
+Run:
+
+```bash
+npm run format:check && npm run lint && npx astro check && npm run build
+```
+
+Expected: all four pass cleanly. This mirrors what CI will run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy.yml package.json package-lock.json
+git commit -m "feat: add CI lint gate with format check, ESLint, and type checking"
+```
+
+---
+
+### Task 5: Final verification and cleanup
+
+- [ ] **Step 1: Run the full CI-equivalent pipeline locally**
+
+Run:
+
+```bash
+npm run format:check && npm run lint && npx astro check && npm run build
+```
+
+Expected: all pass cleanly.
+
+- [ ] **Step 2: Verify the dev server starts correctly**
+
+Run:
+
+```bash
+npm run dev
+```
+
+Expected: dev server starts at `localhost:4321` without errors. Visit the site and verify pages load correctly.
+
+- [ ] **Step 3: Review all scripts in package.json**
+
+Final `scripts` section should be:
+
+```json
+{
+  "dev": "astro dev",
+  "start": "astro dev",
+  "build": "astro build",
+  "preview": "astro preview",
+  "astro": "astro",
+  "lint": "eslint .",
+  "format": "prettier --write .",
+  "format:check": "prettier --check ."
+}
+```

--- a/docs/superpowers/specs/2026-04-18-dependency-hygiene-design.md
+++ b/docs/superpowers/specs/2026-04-18-dependency-hygiene-design.md
@@ -26,23 +26,23 @@ Migrate manually-copied FontAwesome and Roboto files from `public/` to npm-manag
 
 **Files modified:**
 
-| File | Change |
-|------|--------|
-| `astro.config.mjs` | Import and register `icon()` integration |
-| `src/components/Footer.astro` | Import `Icon` from `astro-icon/components`. Remove Twitter link block. Replace 2 remaining `<i class="fa-*">` with `<Icon>` components using `aria-label` |
+| File                            | Change                                                                                                                                                       |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `astro.config.mjs`              | Import and register `icon()` integration                                                                                                                     |
+| `src/components/Footer.astro`   | Import `Icon` from `astro-icon/components`. Remove Twitter link block. Replace 2 remaining `<i class="fa-*">` with `<Icon>` components using `aria-label`    |
 | `src/components/PostList.astro` | Import `Icon` from `astro-icon/components`. Replace `<span class="fa-solid fa-angles-right">` with `<Icon name="fa6-solid:angles-right" aria-hidden="true">` |
-| `src/layouts/Layout.astro` | Remove the 4 FontAwesome `<link>` tags |
+| `src/layouts/Layout.astro`      | Remove the 4 FontAwesome `<link>` tags                                                                                                                       |
 
 **Files deleted:** `public/fontawesome/` (entire directory, ~700 KB)
 
 **Icon mapping:**
 
-| Old | New | Component |
-|-----|-----|-----------|
-| `fa-brands fa-github` | `fa6-brands:github` | Footer.astro |
-| `fa-brands fa-linkedin-in` | `fa6-brands:linkedin-in` | Footer.astro |
+| Old                        | New                      | Component      |
+| -------------------------- | ------------------------ | -------------- |
+| `fa-brands fa-github`      | `fa6-brands:github`      | Footer.astro   |
+| `fa-brands fa-linkedin-in` | `fa6-brands:linkedin-in` | Footer.astro   |
 | `fa-solid fa-angles-right` | `fa6-solid:angles-right` | PostList.astro |
-| `fa-brands fa-twitter` | _(removed)_ | Footer.astro |
+| `fa-brands fa-twitter`     | _(removed)_              | Footer.astro   |
 
 ### Font migration (`@fontsource/roboto`)
 
@@ -50,19 +50,19 @@ Migrate manually-copied FontAwesome and Roboto files from `public/` to npm-manag
 
 **Files modified:**
 
-| File | Change |
-|------|--------|
+| File                    | Change                                                                                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `src/styles/global.css` | Remove 4 `@font-face` blocks. Add `@import "@fontsource/roboto/{300,400,500,700}.css"`. Keep `body { font-family: "Roboto", sans-serif; }` |
 
 **Files deleted:** `public/fonts/` (4 `.ttf` files, ~700 KB)
 
 ### Documentation updates
 
-| File | Change |
-|------|--------|
+| File                         | Change                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `docs/3-design-decisions.md` | Update "Self-hosted fonts and icons" section: assets now managed via npm. Add note about Twitter link removal |
-| `docs/1-tech-stack.md` | Add new dependencies to Runtime table. Update "Assets (self-hosted)" section to reflect npm management |
-| `docs/5-improvements.md` | Remove the entire "Urgent (dependency hygiene)" section (lines 6-143) |
+| `docs/1-tech-stack.md`       | Add new dependencies to Runtime table. Update "Assets (self-hosted)" section to reflect npm management        |
+| `docs/5-improvements.md`     | Remove the entire "Urgent (dependency hygiene)" section (lines 6-143)                                         |
 
 ## Verification
 
@@ -73,6 +73,7 @@ grep -rn "fa-\|fontawesome\|fonts/Roboto\|/fonts/" src/ public/
 ```
 
 Additionally:
+
 - `npm run build` must succeed
 - `npm run dev` must show icons rendering correctly and fonts loading
 - No requests to `/fonts/` or `/fontawesome/` paths in the built output

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,6 @@ export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,
-  prettier,
   {
     rules: {
       "@typescript-eslint/no-unused-vars": [
@@ -20,6 +19,7 @@ export default [
       ],
     },
   },
+  prettier,
   {
     ignores: ["dist/", ".astro/", "node_modules/"],
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,22 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import astro from "eslint-plugin-astro";
+import prettier from "eslint-config-prettier";
 
 export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...astro.configs.recommended,
+  prettier,
   {
     rules: {
       "@typescript-eslint/no-unused-vars": [
         "error",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,20 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import astro from "eslint-plugin-astro";
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...astro.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+    },
+  },
+  {
+    ignores: ["dist/", ".astro/", "node_modules/"],
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,10 @@
         "@iconify-json/fa6-solid": "^1.2.4",
         "@tailwindcss/vite": "^4.2.2",
         "eslint": "^10.2.1",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-astro": "^1.7.0",
+        "prettier": "^3.8.3",
+        "prettier-plugin-astro": "^0.14.1",
         "tailwindcss": "^4.2.2",
         "typescript-eslint": "^8.58.2"
       }
@@ -4004,6 +4007,22 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-astro": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-1.7.0.tgz",
@@ -6605,6 +6624,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-astro/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -7041,11 +7098,28 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -7244,6 +7318,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
       }
     },
     "node_modules/svgo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,42 +69,12 @@
         "typescript": "^5.0.0"
       }
     },
-    "node_modules/@astrojs/check/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@astrojs/check/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@astrojs/compiler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
-      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
-      "license": "MIT",
-      "peer": true
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.8.0",
@@ -156,13 +126,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.1.0",
@@ -217,17 +180,16 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -385,6 +347,28 @@
       "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1537,9 +1521,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
-      "optional": true
-    },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
@@ -1727,6 +1708,7 @@
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1757,6 +1739,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1774,6 +1757,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1791,6 +1775,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1808,6 +1793,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1825,6 +1811,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1842,6 +1829,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1859,6 +1847,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1876,6 +1865,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1893,6 +1883,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1910,6 +1901,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1927,6 +1919,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1944,6 +1937,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1958,6 +1952,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -1967,18 +1962,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
@@ -1986,6 +1969,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2003,6 +1987,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2020,6 +2005,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2029,7 +2015,8 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2902,7 +2889,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3197,7 +3183,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3315,15 +3300,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.7.tgz",
-      "integrity": "sha512-pvZysIUV2C2nRv8N7cXAkCLcfDQz/axAxF09SqiTz1B+xnvbhy6KzL2I6J15ZBXk8k0TfMD75dJ151QyQmAqZA==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.1.8.tgz",
+      "integrity": "sha512-6fT9M12U3fpi13DiPavNKDIoBflASTSxmKTEe+zXhWtlebQuOqfOnIrMWyRmlXp+mgDsojmw+fVFG9LUTzKSog==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^3.0.1",
         "@astrojs/internal-helpers": "0.8.0",
         "@astrojs/markdown-remark": "7.1.0",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
@@ -3489,6 +3474,12 @@
         "@iconify/types": "^2.0.0",
         "@iconify/utils": "^2.1.30"
       }
+    },
+    "node_modules/astro/node_modules/@astrojs/compiler": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
+      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
+      "license": "MIT"
     },
     "node_modules/astro/node_modules/vite": {
       "version": "7.3.2",
@@ -3736,15 +3727,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^5.0.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -4098,18 +4090,6 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
-    "node_modules/dom-serializer/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -4221,9 +4201,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4290,12 +4270,13 @@
       }
     },
     "node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4307,7 +4288,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4459,19 +4439,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/espree": {
@@ -5170,15 +5137,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5235,6 +5202,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5285,7 +5267,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5376,7 +5357,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -5743,6 +5723,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -6933,6 +6925,18 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -7065,7 +7069,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7082,7 +7085,6 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -7091,13 +7093,6 @@
       "engines": {
         "node": "^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/prettier-plugin-astro/node_modules/@astrojs/compiler": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
-      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -7182,12 +7177,13 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
@@ -7465,6 +7461,7 @@
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
         "@rolldown/pluginutils": "1.0.0-rc.15"
@@ -7498,7 +7495,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8010,7 +8006,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -8363,6 +8358,34 @@
         "uploadthing": {
           "optional": true
         }
+      }
+    },
+    "node_modules/unstorage/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/unstorage/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/uri-js": {
@@ -8899,7 +8922,6 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8939,7 +8961,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro-icon": "^1.1.5"
       },
       "devDependencies": {
+        "@astrojs/check": "^0.9.8",
         "@eslint/js": "^10.0.1",
         "@iconify-json/fa6-brands": "^1.2.6",
         "@iconify-json/fa6-solid": "^1.2.4",
@@ -49,6 +50,55 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.8.tgz",
+      "integrity": "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.5",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@astrojs/compiler": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
@@ -64,6 +114,55 @@
       "dependencies": {
         "picomatch": "^4.0.3"
       }
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.6.tgz",
+      "integrity": "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.3",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.15",
+        "volar-service-css": "0.0.70",
+        "volar-service-emmet": "0.0.70",
+        "volar-service-html": "0.0.70",
+        "volar-service-prettier": "0.0.70",
+        "volar-service-typescript": "0.0.70",
+        "volar-service-typescript-twoslash-queries": "0.0.70",
+        "volar-service-yaml": "0.0.70",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.1.0",
@@ -133,6 +232,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -214,6 +323,68 @@
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -2920,6 +3091,104 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2958,6 +3227,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -3476,6 +3771,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3484,6 +3794,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -3827,6 +4157,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -3920,6 +4274,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -4281,6 +4645,23 @@
         "fast-string-truncated-width": "^1.2.0"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-wrap-ansi": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
@@ -4432,6 +4813,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-stream": {
@@ -4800,6 +5191,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4919,6 +5320,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4927,6 +5335,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/kolorist": {
@@ -6205,6 +6623,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6504,6 +6929,13 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6923,6 +7355,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -7306,6 +7765,21 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -7318,6 +7792,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/suf-log": {
@@ -7534,6 +8021,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -7547,6 +8041,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
       }
     },
     "node_modules/typescript-eslint": {
@@ -8012,6 +8516,261 @@
         }
       }
     },
+    "node_modules/volar-service-css": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.20.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -8079,6 +8838,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -8091,6 +8868,16 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -8100,6 +8887,125 @@
         "node": ">=18"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "devOptional": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.5.0",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
@@ -8107,6 +9013,16 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yauzl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,6 +1537,9 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "optional": true
+    },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
@@ -7062,6 +7065,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7078,6 +7082,7 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -8005,6 +8010,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,8 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
       "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.8.0",
@@ -355,6 +356,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -366,6 +368,7 @@
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1708,7 +1711,6 @@
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -1739,7 +1741,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1757,7 +1758,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1775,7 +1775,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1793,7 +1792,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1811,7 +1809,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1829,7 +1826,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1847,7 +1843,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1865,7 +1860,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1883,7 +1877,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1901,7 +1894,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1919,7 +1911,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1937,7 +1928,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -1952,7 +1942,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -1969,7 +1958,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1987,7 +1975,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2005,7 +1992,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -2015,8 +2001,7 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
@@ -2889,6 +2874,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3183,6 +3169,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4288,6 +4275,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5267,6 +5255,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5357,6 +5346,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "devOptional": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -7069,6 +7059,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7085,6 +7076,7 @@
       "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.9.1",
         "prettier": "^3.0.0",
@@ -7461,7 +7453,6 @@
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
         "@rolldown/pluginutils": "1.0.0-rc.15"
@@ -7495,6 +7486,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8922,6 +8914,7 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -8961,6 +8954,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,14 @@
         "astro-icon": "^1.1.5"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@iconify-json/fa6-brands": "^1.2.6",
         "@iconify-json/fa6-solid": "^1.2.4",
         "@tailwindcss/vite": "^4.2.2",
-        "tailwindcss": "^4.2.2"
+        "eslint": "^10.2.1",
+        "eslint-plugin-astro": "^1.7.0",
+        "tailwindcss": "^4.2.2",
+        "typescript-eslint": "^8.58.2"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -46,7 +50,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-3.0.1.tgz",
       "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.8.0",
@@ -634,6 +639,134 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@fontsource/roboto": {
       "version": "5.2.10",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.10.tgz",
@@ -641,6 +774,72 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@iconify-json/fa6-brands": {
@@ -1301,6 +1500,44 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1315,6 +1552,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2343,6 +2593,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2357,6 +2614,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -2387,7 +2651,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2417,6 +2680,237 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -2428,11 +2922,39 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/anymatch": {
@@ -2568,6 +3090,94 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/astro-eslint-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-1.4.0.tgz",
+      "integrity": "sha512-+QDcgc7e+au6EZ0YjMmRRjNoQo5bDMlaR45aWDoFsuxQTCM9qmCHRoiKJPELgckJ8Wmr7vcfpa9eCDHBFh6G4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.0.0 || ^3.0.0",
+        "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0",
+        "@typescript-eslint/types": "^7.0.0 || ^8.0.0",
+        "astrojs-compiler-sync": "^1.0.0",
+        "debug": "^4.3.4",
+        "entities": "^7.0.0",
+        "eslint-scope": "^8.0.1",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.0",
+        "fast-glob": "^3.3.3",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/astro-icon": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/astro-icon/-/astro-icon-1.1.5.tgz",
@@ -2653,6 +3263,25 @@
         }
       }
     },
+    "node_modules/astrojs-compiler-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
+      "integrity": "sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "synckit": "^0.11.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "@astrojs/compiler": ">=0.27.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2672,11 +3301,47 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
@@ -2870,6 +3535,21 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/crossws": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
@@ -2918,6 +3598,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/csso": {
@@ -2982,6 +3675,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/defu": {
       "version": "6.1.7",
@@ -3231,11 +3931,232 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
+      "integrity": "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-astro": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-astro/-/eslint-plugin-astro-1.7.0.tgz",
+      "integrity": "sha512-89xpAn528UKCdmyysbg0AHHqi6sqcK89wXnJIpu4F0mFBN03zATEBNK7pRtMfl6gwtMOm5ECXs+Wz5qDHhwTFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14",
+        "@typescript-eslint/types": "^7.7.1 || ^8",
+        "astro-eslint-parser": "^1.3.0",
+        "eslint-compat-utils": "^0.6.0",
+        "globals": "^16.0.0",
+        "postcss": "^8.4.14",
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.0"
+      }
+    },
+    "node_modules/eslint-plugin-astro/node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -3275,6 +4196,57 @@
         "@types/yauzl": "^2.9.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
@@ -3297,6 +4269,16 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^1.1.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fd-slicer": {
@@ -3324,6 +4306,70 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -3389,6 +4435,19 @@
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/globals": {
       "version": "15.15.0",
@@ -3668,6 +4727,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -3692,6 +4771,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -3708,6 +4810,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3737,6 +4849,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -3760,11 +4879,56 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -4043,6 +5207,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/longest-streak": {
@@ -4324,6 +5504,16 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -4888,6 +6078,49 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -4970,6 +6203,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/neotraverse": {
       "version": "0.6.18",
@@ -5079,6 +6319,24 @@
         "regex-recursion": "^6.0.2"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
@@ -5089,6 +6347,51 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5183,6 +6486,26 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5258,6 +6581,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -5287,6 +6634,16 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/quansync": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -5299,6 +6656,27 @@
         {
           "type": "individual",
           "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
         }
       ],
       "license": "MIT"
@@ -5549,6 +6927,17 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -5628,6 +7017,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5698,6 +7111,29 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shiki": {
@@ -5835,6 +7271,22 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.9"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -5912,6 +7364,19 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -5930,6 +7395,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tsconfck": {
@@ -5958,6 +7436,58 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.3",
@@ -6241,6 +7771,23 @@
         }
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -6413,6 +7960,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -6420,6 +7983,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",
@@ -22,7 +24,10 @@
     "@iconify-json/fa6-solid": "^1.2.4",
     "@tailwindcss/vite": "^4.2.2",
     "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-astro": "^1.7.0",
+    "prettier": "^3.8.3",
+    "prettier-plugin-astro": "^0.14.1",
     "tailwindcss": "^4.2.2",
     "typescript-eslint": "^8.58.2"
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "astro-icon": "^1.1.5"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.8",
     "@eslint/js": "^10.0.1",
     "@iconify-json/fa6-brands": "^1.2.6",
     "@iconify-json/fa6-solid": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",
@@ -16,9 +17,13 @@
     "astro-icon": "^1.1.5"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@iconify-json/fa6-brands": "^1.2.6",
     "@iconify-json/fa6-solid": "^1.2.4",
     "@tailwindcss/vite": "^4.2.2",
-    "tailwindcss": "^4.2.2"
+    "eslint": "^10.2.1",
+    "eslint-plugin-astro": "^1.7.0",
+    "tailwindcss": "^4.2.2",
+    "typescript-eslint": "^8.58.2"
   }
 }

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -13,7 +13,11 @@ const isBlog = pathname.includes("/blog");
     <div
       class="flex flex-row space-x-10 text-zinc-900 dark:text-slate-200 font-bold"
     >
-      <a href={lang === "en" ? "/" : `/${lang}`} class="group" aria-current={isHome ? "page" : undefined}>
+      <a
+        href={lang === "en" ? "/" : `/${lang}`}
+        class="group"
+        aria-current={isHome ? "page" : undefined}
+      >
         {t("nav.home")}
         <span
           class=`${
@@ -21,7 +25,11 @@ const isBlog = pathname.includes("/blog");
           }`
         ></span>
       </a>
-      <a href={lang === "en" ? "/blog" : `/${lang}/blog`} class="group" aria-current={isBlog ? "page" : undefined}>
+      <a
+        href={lang === "en" ? "/blog" : `/${lang}/blog`}
+        class="group"
+        aria-current={isBlog ? "page" : undefined}
+      >
         {t("nav.blog")}
         <span
           class=`${

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -25,18 +25,20 @@ const { posts } = Astro.props;
               <a href={post.url}>
                 <div class="flex flex-col lg:flex-row lg:justify-between">
                   <div class="pb-2 lg:mr-5 w-72">
-                    <Icon name="fa6-solid:angles-right" class="inline mr-2" aria-hidden="true" />
+                    <Icon
+                      name="fa6-solid:angles-right"
+                      class="inline mr-2"
+                      aria-hidden="true"
+                    />
                     {post.frontmatter.title}
                   </div>
-                    <div class="tags pb-2 flex flex-row min-h-fit items-center">
-                    {
-                      post.frontmatter.tags.map((tag) => (
+                  <div class="tags pb-2 flex flex-row min-h-fit items-center">
+                    {post.frontmatter.tags.map((tag) => (
                       <span class="text-xs font-thin text-zinc-900 dark:text-slate-200 bg-zinc-300 dark:bg-slate-800 px-2 py-1 rounded-xl mr-2">
                         {tag}
                       </span>
-                      ))
-                    }
-                    </div>
+                    ))}
+                  </div>
                   <span class="text-gray-500 font-light min-w-fit">
                     {post.frontmatter.pubDate}
                   </span>

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -30,7 +30,9 @@ export function getAlternatePath(
     : pathname === "/es"
       ? "/"
       : pathname;
-  return targetLang === "en" ? stripped : `/es${stripped === "/" ? "/" : stripped}`;
+  return targetLang === "en"
+    ? stripped
+    : `/es${stripped === "/" ? "/" : stripped}`;
 }
 
 export function getRouteFromUrl(url: string): string | undefined {
@@ -52,7 +54,8 @@ export async function getPostTranslations(
   for (const post of relatedPosts) {
     const [lang, ...slugParts] = post.id.split("/");
     const slug = slugParts.join("/");
-    translations[lang] = lang === "en" ? `/blog/${slug}` : `/${lang}/blog/${slug}`;
+    translations[lang] =
+      lang === "en" ? `/blog/${slug}` : `/${lang}/blog/${slug}`;
   }
 
   return translations;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,8 +27,14 @@ const {
 const lang = getLangFromUrl(Astro.url);
 const canonicalPath = getAlternatePath(Astro.url.pathname, lang, translations);
 const canonicalUrl = new URL(canonicalPath, Astro.site);
-const enUrl = new URL(getAlternatePath(Astro.url.pathname, "en", translations), Astro.site);
-const esUrl = new URL(getAlternatePath(Astro.url.pathname, "es", translations), Astro.site);
+const enUrl = new URL(
+  getAlternatePath(Astro.url.pathname, "en", translations),
+  Astro.site,
+);
+const esUrl = new URL(
+  getAlternatePath(Astro.url.pathname, "es", translations),
+  Astro.site,
+);
 ---
 
 <!doctype html>
@@ -54,10 +60,13 @@ const esUrl = new URL(getAlternatePath(Astro.url.pathname, "es", translations), 
 
           // Auto-detection only on the root path. Deep links never bounce.
           if (stored === null && path === "/") {
-            const langs = navigator.languages && navigator.languages.length
-              ? navigator.languages
-              : [navigator.language];
-            const prefersSpanish = langs.some((l) => (l || "").toLowerCase().startsWith("es"));
+            const langs =
+              navigator.languages && navigator.languages.length
+                ? navigator.languages
+                : [navigator.language];
+            const prefersSpanish = langs.some((l) =>
+              (l || "").toLowerCase().startsWith("es"),
+            );
             if (prefersSpanish) {
               localStorage.setItem("lang", "es");
               location.replace("/es/");
@@ -83,17 +92,25 @@ const esUrl = new URL(getAlternatePath(Astro.url.pathname, "es", translations), 
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:type" content={ogType} />
     <meta property="og:locale" content={lang === "es" ? "es_ES" : "en_US"} />
-    <meta property="og:locale:alternate" content={lang === "es" ? "en_US" : "es_ES"} />
+    <meta
+      property="og:locale:alternate"
+      content={lang === "es" ? "en_US" : "es_ES"}
+    />
     <meta property="og:site_name" content="T1b4lt" />
-    {article?.publishedTime && (
-      <meta property="article:published_time" content={article.publishedTime} />
-    )}
-    {article?.author && (
-      <meta property="article:author" content={article.author} />
-    )}
-    {article?.tags?.map((tag) => (
-      <meta property="article:tag" content={tag} />
-    ))}
+    {
+      article?.publishedTime && (
+        <meta
+          property="article:published_time"
+          content={article.publishedTime}
+        />
+      )
+    }
+    {
+      article?.author && (
+        <meta property="article:author" content={article.author} />
+      )
+    }
+    {article?.tags?.map((tag) => <meta property="article:tag" content={tag} />)}
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content={title} />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,12 +1,19 @@
 ---
 import Layout from "./Layout.astro";
 import "../styles/post.css";
+import type { CollectionEntry } from "astro:content";
 
 import {
   getLangFromUrl,
   useTranslations,
   getAlternatePath,
 } from "../i18n/utils";
+
+interface Props {
+  frontmatter: CollectionEntry<"blog">["data"];
+  translations?: Record<string, string>;
+}
+
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 
@@ -56,7 +63,7 @@ const jsonLd = {
       <h2 class="text-base font-light">{subtitle}</h2>
       <div class="flex flex-row mt-5">
         {
-          frontmatter.tags.map((tag: string) => (
+          frontmatter.tags.map((tag) => (
             <span class="text-xs font-thin text-zinc-900 dark:text-slate-200 bg-zinc-300 dark:bg-slate-800 px-2 py-1 rounded-xl mr-2">
               {tag}
             </span>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -2,7 +2,11 @@
 import Layout from "./Layout.astro";
 import "../styles/post.css";
 
-import { getLangFromUrl, useTranslations, getAlternatePath } from "../i18n/utils";
+import {
+  getLangFromUrl,
+  useTranslations,
+  getAlternatePath,
+} from "../i18n/utils";
 const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 
@@ -45,7 +49,7 @@ const jsonLd = {
     tags: frontmatter.tags,
   }}
 >
-  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
+  <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
   <div class="flex justify-center p-10">
     <div class="w-full lg:w-1/2 text-lg">
       <h1 class="text-4xl font-bold">{frontmatter.title}</h1>
@@ -53,9 +57,9 @@ const jsonLd = {
       <div class="flex flex-row mt-5">
         {
           frontmatter.tags.map((tag: string) => (
-        <span class="text-xs font-thin text-zinc-900 dark:text-slate-200 bg-zinc-300 dark:bg-slate-800 px-2 py-1 rounded-xl mr-2">
-          {tag}
-        </span>
+            <span class="text-xs font-thin text-zinc-900 dark:text-slate-200 bg-zinc-300 dark:bg-slate-800 px-2 py-1 rounded-xl mr-2">
+              {tag}
+            </span>
           ))
         }
       </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,18 +2,22 @@
 import Layout from "../layouts/Layout.astro";
 import { getLangFromUrl, useTranslations } from "../i18n/utils";
 
-import { Image } from 'astro:assets';
+import { Image } from "astro:assets";
 import lostImage from "../../public/images/lost.gif";
 
 const lang = getLangFromUrl(Astro.url);
-const t = useTranslations(lang)
+const t = useTranslations(lang);
 ---
+
 <Layout title="404">
-    <div class="flex flex-col items-center h-screen">
+  <div class="flex flex-col items-center h-screen">
     <h1 class="text-3xl font-bold mt-20">{t("404.title")}</h1>
-    <Image src={lostImage} alt="Lost astronaut illustration" class="mt-20"/>
-    <a href={lang === "en" ? "/" : `/${lang}`} class="text-slate-200 bg-gradient-to-br from-purple-600 to-blue-500 hover:bg-gradient-to-bl focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mt-20">
-        <span>{t("404.button")}</span>
+    <Image src={lostImage} alt="Lost astronaut illustration" class="mt-20" />
+    <a
+      href={lang === "en" ? "/" : `/${lang}`}
+      class="text-slate-200 bg-gradient-to-br from-purple-600 to-blue-500 hover:bg-gradient-to-bl focus:ring-4 focus:outline-none focus:ring-blue-300 dark:focus:ring-blue-800 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mt-20"
+    >
+      <span>{t("404.button")}</span>
     </a>
-    </div>
+  </div>
 </Layout>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -6,6 +6,9 @@ import { getFormattedPosts } from "../i18n/utils";
 const posts = await getFormattedPosts("en");
 ---
 
-<Layout title="T1b4lt | Blog" description="Blog posts about technology, innovation and professional growth">
+<Layout
+  title="T1b4lt | Blog"
+  description="Blog posts about technology, innovation and professional growth"
+>
   <PostList posts={posts} />
 </Layout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,7 +1,7 @@
 ---
-import { render } from 'astro:content';
-import PostLayout from '../../layouts/PostLayout.astro';
-import { getBlogStaticPaths, getPostTranslations } from '../../i18n/utils';
+import { render } from "astro:content";
+import PostLayout from "../../layouts/PostLayout.astro";
+import { getBlogStaticPaths, getPostTranslations } from "../../i18n/utils";
 
 export async function getStaticPaths() {
   return getBlogStaticPaths("en");
@@ -9,7 +9,7 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
-const translations = await getPostTranslations(entry.data.idx, 'en');
+const translations = await getPostTranslations(entry.data.idx, "en");
 ---
 
 <PostLayout frontmatter={entry.data} translations={translations}>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,11 +1,14 @@
 ---
 import { render } from "astro:content";
+import type { InferGetStaticPropsType } from "astro";
 import PostLayout from "../../layouts/PostLayout.astro";
 import { getBlogStaticPaths, getPostTranslations } from "../../i18n/utils";
 
 export async function getStaticPaths() {
   return getBlogStaticPaths("en");
 }
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);

--- a/src/pages/es/blog.astro
+++ b/src/pages/es/blog.astro
@@ -6,6 +6,9 @@ import { getFormattedPosts } from "../../i18n/utils";
 const posts = await getFormattedPosts("es");
 ---
 
-<Layout title="T1b4lt | Blog" description="Publicaciones sobre tecnología, innovación y crecimiento profesional">
+<Layout
+  title="T1b4lt | Blog"
+  description="Publicaciones sobre tecnología, innovación y crecimiento profesional"
+>
   <PostList posts={posts} />
 </Layout>

--- a/src/pages/es/blog/[slug].astro
+++ b/src/pages/es/blog/[slug].astro
@@ -1,7 +1,7 @@
 ---
-import { render } from 'astro:content';
-import PostLayout from '../../../layouts/PostLayout.astro';
-import { getBlogStaticPaths, getPostTranslations } from '../../../i18n/utils';
+import { render } from "astro:content";
+import PostLayout from "../../../layouts/PostLayout.astro";
+import { getBlogStaticPaths, getPostTranslations } from "../../../i18n/utils";
 
 export async function getStaticPaths() {
   return getBlogStaticPaths("es");
@@ -9,7 +9,7 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);
-const translations = await getPostTranslations(entry.data.idx, 'es');
+const translations = await getPostTranslations(entry.data.idx, "es");
 ---
 
 <PostLayout frontmatter={entry.data} translations={translations}>

--- a/src/pages/es/blog/[slug].astro
+++ b/src/pages/es/blog/[slug].astro
@@ -1,11 +1,14 @@
 ---
 import { render } from "astro:content";
+import type { InferGetStaticPropsType } from "astro";
 import PostLayout from "../../../layouts/PostLayout.astro";
 import { getBlogStaticPaths, getPostTranslations } from "../../../i18n/utils";
 
 export async function getStaticPaths() {
   return getBlogStaticPaths("es");
 }
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
 const { entry } = Astro.props;
 const { Content } = await render(entry);

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -35,7 +35,7 @@ import Layout from "../../layouts/Layout.astro";
           </li>
         </ul>
       </p>
-      <h2 class="text-3xl font-bold">Mis áreas de interes</h2>
+      <h2 class="text-3xl font-bold">Mis áreas de interés</h2>
       <p>
         Como profesional, mi curiosidad y pasión me llevan a explorar diversas
         áreas:
@@ -78,7 +78,7 @@ import Layout from "../../layouts/Layout.astro";
           </li>
           <li>
             <b>• Contribuir a la Comunidad:</b> Compartir lo que sé y aprender de
-            otros. La colaboración en el ambito tecnologico es clave para alcanzar
+            otros. La colaboración en el ámbito tecnológico es clave para alcanzar
             metas inimaginables. Realmente creo en el poder y la filosofía del Open
             Source
           </li>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -27,73 +27,72 @@ import Layout from "../../layouts/Layout.astro";
         emergentes para mejorar los productos existentes y desarrollar otros
         nuevos. Mi trabajo consiste en llevar a cabo el prototipado rápido de
         productos digitales, aplicando estas tecnologías emergentes para:
-        <ul class="space-y-4 ml-4">
-          <li>1. mejorar las soluciones existentes,</li>
-          <li>2. crear nuevas experiencias para nuestros usuarios y</li>
-          <li>
-            3. deshacer la incertidumbre que rodea a estas nuevas tecnologías.
-          </li>
-        </ul>
       </p>
+      <ul class="space-y-4 ml-4">
+        <li>1. mejorar las soluciones existentes,</li>
+        <li>2. crear nuevas experiencias para nuestros usuarios y</li>
+        <li>
+          3. deshacer la incertidumbre que rodea a estas nuevas tecnologías.
+        </li>
+      </ul>
       <h2 class="text-3xl font-bold">Mis áreas de interés</h2>
       <p>
         Como profesional, mi curiosidad y pasión me llevan a explorar diversas
         áreas:
-        <ul class="space-y-4 ml-4">
-          <li>
-            <b>• Machine Learning:</b> Me fascina el potencial de las técnicas de
-            aprendizaje automático para transformar la forma en que interactuamos
-            con la tecnología. Desde los tradicionales algoritmos de clasificación
-            y redes neuronales hasta las nuevas corrientes de IA Generativa, que tantas
-            oportunidades nos está dando. Siempre estoy buscando aprender más y aplicar
-            estos conocimientos en proyectos innovadores.
-          </li>
-          <li>
-            <b>• Desarrollo de Software y Aplicaciones:</b> La programación fue mi
-            puerta de entrada al mundo de la tecnología. Me encanta construir soluciones
-            desde cero, ya sea desarrollando aplicaciones web, móviles, sistemas backend
-            o todo a la vez para una única solución. La creatividad, la resolución
-            de problemas y crear soluciones tangibles son mi motor.
-          </li>
-          <li>
-            <b>• Análisis de Datos:</b> Los datos son el nuevo petróleo, y yo soy
-            un apasionado geólogo. Explorar conjuntos de datos, extraer conocimientos
-            y tomar decisiones basadas en evidencia es algo que me apasiona. Desde
-            SQL hasta herramientas de visualización, siempre estoy afinando mis habilidades
-            analíticas.
-          </li>
-        </ul>
       </p>
+      <ul class="space-y-4 ml-4">
+        <li>
+          <b>• Machine Learning:</b> Me fascina el potencial de las técnicas de aprendizaje
+          automático para transformar la forma en que interactuamos con la tecnología.
+          Desde los tradicionales algoritmos de clasificación y redes neuronales hasta
+          las nuevas corrientes de IA Generativa, que tantas oportunidades nos está
+          dando. Siempre estoy buscando aprender más y aplicar estos conocimientos
+          en proyectos innovadores.
+        </li>
+        <li>
+          <b>• Desarrollo de Software y Aplicaciones:</b> La programación fue mi puerta
+          de entrada al mundo de la tecnología. Me encanta construir soluciones desde
+          cero, ya sea desarrollando aplicaciones web, móviles, sistemas backend o
+          todo a la vez para una única solución. La creatividad, la resolución de
+          problemas y crear soluciones tangibles son mi motor.
+        </li>
+        <li>
+          <b>• Análisis de Datos:</b> Los datos son el nuevo petróleo, y yo soy un
+          apasionado geólogo. Explorar conjuntos de datos, extraer conocimientos y
+          tomar decisiones basadas en evidencia es algo que me apasiona. Desde SQL
+          hasta herramientas de visualización, siempre estoy afinando mis habilidades
+          analíticas.
+        </li>
+      </ul>
       <h2 class="text-3xl font-bold">Mis metas profesionales</h2>
       <p>
         Mi camino profesional está enfocado hacia el crecimiento continuo.
         Aspiro a:
-        <ul class="space-y-4 ml-4">
-          <li>
-            <b>• Seguir Aprendiendo:</b> Nunca dejar de aprender. Siento, <i
-              >y espero</i
-            >, que esta curiosidad que me suscita todo lo relacionado con la
-            tecnología y la innovación no va cesar. Cursos, conferencias,
-            libros… cualquier fuente de conocimiento es bienvenida.
-          </li>
-          <li>
-            <b>• Contribuir a la Comunidad:</b> Compartir lo que sé y aprender de
-            otros. La colaboración en el ámbito tecnológico es clave para alcanzar
-            metas inimaginables. Realmente creo en el poder y la filosofía del Open
-            Source
-          </li>
-          <li>
-            <b>• Innovar:</b> Siempre buscar nuevas formas de resolver problemas y
-            crear soluciones disruptivas. Mantenerme al día de lo que ocurre en este
-            mundo y encajar las piezas de formas que no se han encajado antes.
-          </li>
-          <li>
-            <b>• Crear:</b> Construir soluciones tangibles que tengan un impacto positivo.
-            Desde aplicaciones móviles hasta sistemas de inteligencia artificial,
-            siempre estoy buscando crear soluciones que lleguen a las personas.
-          </li>
-        </ul>
       </p>
+      <ul class="space-y-4 ml-4">
+        <li>
+          <b>• Seguir Aprendiendo:</b> Nunca dejar de aprender. Siento, <i
+            >y espero</i
+          >, que esta curiosidad que me suscita todo lo relacionado con la
+          tecnología y la innovación no va cesar. Cursos, conferencias, libros…
+          cualquier fuente de conocimiento es bienvenida.
+        </li>
+        <li>
+          <b>• Contribuir a la Comunidad:</b> Compartir lo que sé y aprender de otros.
+          La colaboración en el ámbito tecnológico es clave para alcanzar metas inimaginables.
+          Realmente creo en el poder y la filosofía del Open Source
+        </li>
+        <li>
+          <b>• Innovar:</b> Siempre buscar nuevas formas de resolver problemas y crear
+          soluciones disruptivas. Mantenerme al día de lo que ocurre en este mundo
+          y encajar las piezas de formas que no se han encajado antes.
+        </li>
+        <li>
+          <b>• Crear:</b> Construir soluciones tangibles que tengan un impacto positivo.
+          Desde aplicaciones móviles hasta sistemas de inteligencia artificial, siempre
+          estoy buscando crear soluciones que lleguen a las personas.
+        </li>
+      </ul>
       <h2 class="text-3xl font-bold">Visita mi blog</h2>
       <p>
         En este blog, compartiré mis experiencias, conocimientos y opiniones

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -2,55 +2,105 @@
 import Layout from "../../layouts/Layout.astro";
 ---
 
-<Layout title="T1b4lt | Inicio" description="Guillermo Segovia - Profesional IT enfocado en innovación, machine learning y desarrollo de software en Telefónica">
+<Layout
+  title="T1b4lt | Inicio"
+  description="Guillermo Segovia - Profesional IT enfocado en innovación, machine learning y desarrollo de software en Telefónica"
+>
   <div class="flex justify-center p-10">
     <div class="w-full lg:w-1/2 space-y-5 text-lg">
       <hr class="border-zinc-900 dark:border-slate-200" />
-      <h1 class="text-3xl font-bold">Guillermo: Innovación, Tecnología y Crecimiento Constante</h1>
+      <h1 class="text-3xl font-bold">
+        Guillermo: Innovación, Tecnología y Crecimiento Constante
+      </h1>
       <hr class="my-6 border-zinc-900 dark:border-slate-200" />
       <p>
-        ¡Bienvenidos a mi blog, el blog de Guillermo!
-        Soy Guillermo, un profesional (<i>apasionado</i>) de la informática con una trayectoria en el área de innovación y desarrollo digital.
-        Permíteme presentarte mi historia y mis intereses.
+        ¡Bienvenidos a mi blog, el blog de Guillermo! Soy Guillermo, un
+        profesional (<i>apasionado</i>) de la informática con una trayectoria en
+        el área de innovación y desarrollo digital. Permíteme presentarte mi
+        historia y mis intereses.
       </p>
       <h2 class="text-3xl font-bold">Sobre mí</h2>
       <p>
-        Actualmente trabajando en el área de innovación CDO en Telefónica, en una posición que me permite participar en el prototipado rápido de productos digitales.
-        Mi equipo está especializado en aplicar tecnologías emergentes para mejorar los productos existentes y desarrollar otros nuevos.
-        Mi trabajo consiste en llevar a cabo el prototipado rápido de productos digitales, aplicando estas tecnologías emergentes para:
+        Actualmente trabajando en el área de innovación CDO en Telefónica, en
+        una posición que me permite participar en el prototipado rápido de
+        productos digitales. Mi equipo está especializado en aplicar tecnologías
+        emergentes para mejorar los productos existentes y desarrollar otros
+        nuevos. Mi trabajo consiste en llevar a cabo el prototipado rápido de
+        productos digitales, aplicando estas tecnologías emergentes para:
         <ul class="space-y-4 ml-4">
           <li>1. mejorar las soluciones existentes,</li>
           <li>2. crear nuevas experiencias para nuestros usuarios y</li>
-          <li>3. deshacer la incertidumbre que rodea a estas nuevas tecnologías.</li>
+          <li>
+            3. deshacer la incertidumbre que rodea a estas nuevas tecnologías.
+          </li>
         </ul>
       </p>
       <h2 class="text-3xl font-bold">Mis áreas de interes</h2>
       <p>
-        Como profesional, mi curiosidad y pasión me llevan a explorar diversas áreas:
+        Como profesional, mi curiosidad y pasión me llevan a explorar diversas
+        áreas:
         <ul class="space-y-4 ml-4">
-          <li><b>• Machine Learning:</b> Me fascina el potencial de las técnicas de aprendizaje automático para transformar la forma en que interactuamos con la tecnología. Desde los tradicionales algoritmos de clasificación y redes neuronales hasta las nuevas corrientes de IA Generativa, que tantas oportunidades nos está dando. Siempre estoy buscando aprender más y aplicar estos conocimientos en proyectos innovadores.</li>
-          <li><b>• Desarrollo de Software y Aplicaciones:</b> La programación fue mi puerta de entrada al mundo de la tecnología. Me encanta construir soluciones desde cero, ya sea desarrollando aplicaciones web, móviles, sistemas backend o todo a la vez para una única solución. La creatividad, la resolución de problemas y crear soluciones tangibles son mi motor.</li>
-          <li><b>• Análisis de Datos:</b> Los datos son el nuevo petróleo, y yo soy un apasionado geólogo. Explorar conjuntos de datos, extraer conocimientos y tomar decisiones basadas en evidencia es algo que me apasiona. Desde SQL hasta herramientas de visualización, siempre estoy afinando mis habilidades analíticas.</li>
+          <li>
+            <b>• Machine Learning:</b> Me fascina el potencial de las técnicas de
+            aprendizaje automático para transformar la forma en que interactuamos
+            con la tecnología. Desde los tradicionales algoritmos de clasificación
+            y redes neuronales hasta las nuevas corrientes de IA Generativa, que tantas
+            oportunidades nos está dando. Siempre estoy buscando aprender más y aplicar
+            estos conocimientos en proyectos innovadores.
+          </li>
+          <li>
+            <b>• Desarrollo de Software y Aplicaciones:</b> La programación fue mi
+            puerta de entrada al mundo de la tecnología. Me encanta construir soluciones
+            desde cero, ya sea desarrollando aplicaciones web, móviles, sistemas backend
+            o todo a la vez para una única solución. La creatividad, la resolución
+            de problemas y crear soluciones tangibles son mi motor.
+          </li>
+          <li>
+            <b>• Análisis de Datos:</b> Los datos son el nuevo petróleo, y yo soy
+            un apasionado geólogo. Explorar conjuntos de datos, extraer conocimientos
+            y tomar decisiones basadas en evidencia es algo que me apasiona. Desde
+            SQL hasta herramientas de visualización, siempre estoy afinando mis habilidades
+            analíticas.
+          </li>
         </ul>
       </p>
       <h2 class="text-3xl font-bold">Mis metas profesionales</h2>
       <p>
-        Mi camino profesional está enfocado hacia el crecimiento continuo. Aspiro a:
+        Mi camino profesional está enfocado hacia el crecimiento continuo.
+        Aspiro a:
         <ul class="space-y-4 ml-4">
-          <li><b>• Seguir Aprendiendo:</b> Nunca dejar de aprender. Siento, <i>y espero</i>, que esta curiosidad que me suscita todo lo relacionado con la tecnología y la innovación no va cesar. Cursos, conferencias, libros… cualquier fuente de conocimiento es bienvenida.</li>
-          <li><b>• Contribuir a la Comunidad:</b> Compartir lo que sé y aprender de otros. La colaboración en el ambito tecnologico es clave para alcanzar metas inimaginables. Realmente creo en el poder y la filosofía del Open Source</li>
-          <li><b>• Innovar:</b> Siempre buscar nuevas formas de resolver problemas y crear soluciones disruptivas. Mantenerme al día de lo que ocurre en este mundo y encajar las piezas de formas que no se han encajado antes.</li>
-          <li><b>• Crear:</b> Construir soluciones tangibles que tengan un impacto positivo. Desde aplicaciones móviles hasta sistemas de inteligencia artificial, siempre estoy buscando crear soluciones que lleguen a las personas.</li>
+          <li>
+            <b>• Seguir Aprendiendo:</b> Nunca dejar de aprender. Siento, <i
+              >y espero</i
+            >, que esta curiosidad que me suscita todo lo relacionado con la
+            tecnología y la innovación no va cesar. Cursos, conferencias,
+            libros… cualquier fuente de conocimiento es bienvenida.
+          </li>
+          <li>
+            <b>• Contribuir a la Comunidad:</b> Compartir lo que sé y aprender de
+            otros. La colaboración en el ambito tecnologico es clave para alcanzar
+            metas inimaginables. Realmente creo en el poder y la filosofía del Open
+            Source
+          </li>
+          <li>
+            <b>• Innovar:</b> Siempre buscar nuevas formas de resolver problemas y
+            crear soluciones disruptivas. Mantenerme al día de lo que ocurre en este
+            mundo y encajar las piezas de formas que no se han encajado antes.
+          </li>
+          <li>
+            <b>• Crear:</b> Construir soluciones tangibles que tengan un impacto positivo.
+            Desde aplicaciones móviles hasta sistemas de inteligencia artificial,
+            siempre estoy buscando crear soluciones que lleguen a las personas.
+          </li>
         </ul>
       </p>
       <h2 class="text-3xl font-bold">Visita mi blog</h2>
       <p>
-        En este blog, compartiré mis experiencias, conocimientos y opiniones sobre temas relacionados con la tecnología, la innovación y el crecimiento profesional.
-        ¡Espero que disfrutes de la lectura!
+        En este blog, compartiré mis experiencias, conocimientos y opiniones
+        sobre temas relacionados con la tecnología, la innovación y el
+        crecimiento profesional. ¡Espero que disfrutes de la lectura!
       </p>
-      <p>
-        ¡Hasta pronto!
-      </p>
+      <p>¡Hasta pronto!</p>
     </div>
-    </div>
+  </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,22 +2,30 @@
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="T1b4lt | Home" description="Guillermo Segovia - IT professional focused on innovation, machine learning, and software development at Telefonica">
+<Layout
+  title="T1b4lt | Home"
+  description="Guillermo Segovia - IT professional focused on innovation, machine learning, and software development at Telefonica"
+>
   <div class="flex justify-center p-10">
     <div class="w-full lg:w-1/2 space-y-5 text-lg">
       <hr class="border-zinc-900 dark:border-slate-200" />
-      <h1 class="text-3xl font-bold">Guillermo: Innovation, Technology and Constant Growth</h1>
+      <h1 class="text-3xl font-bold">
+        Guillermo: Innovation, Technology and Constant Growth
+      </h1>
       <hr class="my-6 border-zinc-900 dark:border-slate-200" />
       <p>
-        Welcome to my blog, Guillermo's blog!
-        I'm Guillermo, a passionate IT professional with a background in innovation and digital development.
+        Welcome to my blog, Guillermo's blog! I'm Guillermo, a passionate IT
+        professional with a background in innovation and digital development.
         Let me introduce you to my story and interests.
       </p>
       <h2 class="text-3xl font-bold">About me</h2>
       <p>
-        Currently working in the CDO innovation area at Telefónica, in a position that allows me to participate in the rapid prototyping of digital products.
-        My team is specialized in applying emerging technologies to improve existing products and develop new ones.
-        My job is to carry out the rapid prototyping of digital products, applying these emerging technologies to:
+        Currently working in the CDO innovation area at Telefónica, in a
+        position that allows me to participate in the rapid prototyping of
+        digital products. My team is specialized in applying emerging
+        technologies to improve existing products and develop new ones. My job
+        is to carry out the rapid prototyping of digital products, applying
+        these emerging technologies to:
       </p>
       <ul class="space-y-4 ml-4">
         <li>1. improve existing solutions,</li>
@@ -26,31 +34,63 @@ import Layout from "../layouts/Layout.astro";
       </ul>
       <h2 class="text-3xl font-bold">My areas of interest</h2>
       <p>
-        As a professional, my curiosity and passion lead me to explore diverse areas:
+        As a professional, my curiosity and passion lead me to explore diverse
+        areas:
       </p>
       <ul class="space-y-4 ml-4">
-        <li><b>• Machine Learning:</b> I am fascinated by the potential of machine learning techniques to transform the way we interact with technology. From traditional classification algorithms and neural networks to new Generative AI trends, which are giving us so many opportunities. I am always looking to learn more and apply this knowledge in innovative projects.</li>
-        <li><b>• Software and Application Development:</b> Programming was my gateway to the world of technology. I love building solutions from scratch, whether it's developing web, mobile, backend systems or all at once for a single solution. Creativity, problem solving and creating tangible solutions are my driving force.</li>
-        <li><b>• Data Analysis:</b> Data is the new oil, and I am a passionate geologist. Exploring data sets, extracting insights and making evidence-based decisions is something I am passionate about. From SQL to visualization tools, I am always honing my analytical skills.</li>
+        <li>
+          <b>• Machine Learning:</b> I am fascinated by the potential of machine learning
+          techniques to transform the way we interact with technology. From traditional
+          classification algorithms and neural networks to new Generative AI trends,
+          which are giving us so many opportunities. I am always looking to learn
+          more and apply this knowledge in innovative projects.
+        </li>
+        <li>
+          <b>• Software and Application Development:</b> Programming was my gateway
+          to the world of technology. I love building solutions from scratch, whether
+          it's developing web, mobile, backend systems or all at once for a single
+          solution. Creativity, problem solving and creating tangible solutions are
+          my driving force.
+        </li>
+        <li>
+          <b>• Data Analysis:</b> Data is the new oil, and I am a passionate geologist.
+          Exploring data sets, extracting insights and making evidence-based decisions
+          is something I am passionate about. From SQL to visualization tools, I am
+          always honing my analytical skills.
+        </li>
       </ul>
       <h2 class="text-3xl font-bold">My professional goals</h2>
-      <p>
-        My professional path is focused on continuous growth. I aspire to:
-      </p>
+      <p>My professional path is focused on continuous growth. I aspire to:</p>
       <ul class="space-y-4 ml-4">
-        <li><b>• Keep Learning:</b> Never stop learning. I feel, <i>and hope</i>, that this curiosity that technology and innovation arouses in me will not cease. Courses, conferences, books... any source of knowledge is welcome.</li>
-        <li><b>• Contribute to the Community:</b> Share what I know and learn from others. Collaboration in the technological field is key to achieving unimaginable goals. I really believe in the power and philosophy of Open Source</li>
-        <li><b>• Innovate:</b> Always look for new ways to solve problems and create disruptive solutions. Keeping up to date with what is happening in this world and fitting the pieces together in ways that have not been done before.</li>
-        <li><b>• Create:</b> Build tangible solutions that have a positive impact. From mobile applications to artificial intelligence systems, I am always looking to create solutions that reach people.</li>
+        <li>
+          <b>• Keep Learning:</b> Never stop learning. I feel, <i>and hope</i>,
+          that this curiosity that technology and innovation arouses in me will
+          not cease. Courses, conferences, books... any source of knowledge is
+          welcome.
+        </li>
+        <li>
+          <b>• Contribute to the Community:</b> Share what I know and learn from others.
+          Collaboration in the technological field is key to achieving unimaginable
+          goals. I really believe in the power and philosophy of Open Source
+        </li>
+        <li>
+          <b>• Innovate:</b> Always look for new ways to solve problems and create
+          disruptive solutions. Keeping up to date with what is happening in this
+          world and fitting the pieces together in ways that have not been done before.
+        </li>
+        <li>
+          <b>• Create:</b> Build tangible solutions that have a positive impact. From
+          mobile applications to artificial intelligence systems, I am always looking
+          to create solutions that reach people.
+        </li>
       </ul>
       <h2 class="text-3xl font-bold">Visit my blog</h2>
       <p>
-        In this blog, I will share my experiences, knowledge and opinions on topics related to technology, innovation and professional growth.
-        I hope you enjoy reading it!
+        In this blog, I will share my experiences, knowledge and opinions on
+        topics related to technology, innovation and professional growth. I hope
+        you enjoy reading it!
       </p>
-      <p>
-        See you soon!
-      </p>
+      <p>See you soon!</p>
     </div>
   </div>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,8 +8,8 @@
 @variant dark (.dark &);
 
 @theme {
-  --color-primary: #3E78B2;
-  --color-highlight: #D0E562;
+  --color-primary: #3e78b2;
+  --color-highlight: #d0e562;
 }
 
 body {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "astro/tsconfigs/base"
+  "extends": "astro/tsconfigs/strict"
 }


### PR DESCRIPTION
## Summary

- **ESLint** with `eslint-plugin-astro` and `typescript-eslint` for linting `.ts`, `.js`, and `.astro` files
- **Prettier** with `prettier-plugin-astro` for consistent formatting across the codebase
- **TypeScript strict mode** via `astro/tsconfigs/strict` with proper `Props` interfaces added where missing
- **CI lint gate** in GitHub Actions — `format:check`, `lint`, and `astro check` must pass before the site builds

## New scripts

| Script | Purpose |
|--------|---------|
| `npm run lint` | Run ESLint |
| `npm run format` | Format all files with Prettier |
| `npm run format:check` | Check formatting (used in CI) |

## New dev dependencies

`eslint`, `@eslint/js`, `eslint-plugin-astro`, `typescript-eslint`, `eslint-config-prettier`, `prettier`, `prettier-plugin-astro`, `@astrojs/check`

## Test plan

- [x] `npm run lint` passes cleanly
- [x] `npm run format:check` passes cleanly
- [x] `npx astro check` — 0 errors, 0 warnings
- [x] `npm run build` — 9 pages built successfully
- [x] CI workflow runs lint job before build on push to main